### PR TITLE
Refactor HeatShockTransformation transfer logic and add protocol generator improvements

### DIFF
--- a/scripts/Automated_Golden_Gate.py
+++ b/scripts/Automated_Golden_Gate.py
@@ -6,7 +6,7 @@ metadata = {
     'protocolName': 'Automated Golden Gate',
     'author': 'Gonzalo Vidal <gsvidal@uc.cl>, Carlos Vidal-Céspedes <carlos.vidal.c@ug.uchile.cl>',
     'description': 'Protocol to perform a Golden Gate experiment',
-    'apiLevel': '2.10'
+    'apiLevel': '2.14'
 }
 
 def run(protocol: protocol_api.ProtocolContext):

--- a/scripts/run_Bacterial_Transformation.py
+++ b/scripts/run_Bacterial_Transformation.py
@@ -8,8 +8,16 @@ metadata = {
 'description': 'Automated transformation protocol',
 'apiLevel': '2.22'}
 
+transformation_data = [
+    {
+        'Strain': 'composite_strain_1',
+        'Chassis': 'DH5alpha',
+        'Plasmids': ['composite_plasmid_1']
+    }
+]
+
 def run(protocol= protocol_api.ProtocolContext):
 
-    pudu_transformation = HeatShockTransformation(list_of_dna=['pro', 'rbs','cds', 'ter'], competent_cells = 'DH5alpha')
+    pudu_transformation = HeatShockTransformation(transformation_data=transformation_data)
     pudu_transformation.run(protocol)
 #After simulation look at the beginning of the output to see the position of input reagents and outputs.

--- a/scripts/run_Chemical_Transformation_libre.py
+++ b/scripts/run_Chemical_Transformation_libre.py
@@ -176,7 +176,7 @@ class Chemical_transformation(Transformation):
         'protocolName': 'PUDU Transformation',
         'author': 'Gonzalo Vidal <gsvidal@uc.cl>',
         'description': 'Automated transformation protocol',
-        'apiLevel': '2.13'}
+        'apiLevel': '2.14'}
 
     def run(self, protocol: protocol_api.ProtocolContext): 
 
@@ -301,7 +301,7 @@ metadata = {
 'protocolName': 'PUDU Transformation',
 'author': 'Gonzalo Vidal <g.a.vidal-pena2@ncl.ac.uk>',
 'description': 'Automated transformation protocol',
-'apiLevel': '2.13'}
+'apiLevel': '2.14'}
 
 def run(protocol= protocol_api.ProtocolContext):
 

--- a/scripts/run_Loop_assembly_libre.py
+++ b/scripts/run_Loop_assembly_libre.py
@@ -296,7 +296,7 @@ metadata = {
 'protocolName': 'PUDU Loop assembly',
 'author': 'Gonzalo Vidal <g.a.vidal-pena2@ncl.ac.uk>',
 'description': 'Automated DNA assembly Loop protocol',
-'apiLevel': '2.13'}
+'apiLevel': '2.14'}
 
 def run(protocol= protocol_api.ProtocolContext):
 

--- a/scripts/run_sbol2assembly_libre.py
+++ b/scripts/run_sbol2assembly_libre.py
@@ -289,7 +289,7 @@ metadata = {
 'protocolName': 'PUDU Loop assembly',
 'author': 'Gonzalo Vidal <g.a.vidal-pena2@ncl.ac.uk>',
 'description': 'Automated DNA assembly Loop protocol',
-'apiLevel': '2.13'}
+'apiLevel': '2.14'}
 
 def run(protocol= protocol_api.ProtocolContext):
 

--- a/scripts/run_sbol2transformation_with_params.py
+++ b/scripts/run_sbol2transformation_with_params.py
@@ -1,19 +1,14 @@
-transformation_data = {
-    'list_of_dna': ['GVD0011', 'GVD0013', 'GVD0015'],
-    'competent_cells': 'DH5alpha'
-}
-
-advanced_params = {
-    'replicates': 3,
-    'volume_dna': 25,
-    'thermocycler_starting_well': 0,
-    'transfer_volume_dna': 5,
-    'tube_volume_competent_cell': 150
-}
-
 from pudu.transformation import HeatShockTransformation
 from opentrons import protocol_api
 
+
+transformation_data = [
+    {
+        'Strain': 'GVD_strain',
+        'Chassis': 'DH5alpha',
+        'Plasmids': ['GVD0011', 'GVD0013', 'GVD0015']
+    }
+]
 
 # Protocol metadata
 metadata = {
@@ -29,18 +24,11 @@ def run(protocol: protocol_api.ProtocolContext):
 
     transformation = HeatShockTransformation(
         transformation_data=transformation_data,
-        advanced_params=advanced_params
+        replicates=3,
+        volume_dna=25,
+        thermocycler_starting_well=0,
+        transfer_volume_dna=5,
+        tube_volume_competent_cell=150
     )
-
-    # OLD APPROACH: Using kwargs directly (commented out)
-    # transformation = HeatShockTransformation(
-    #     list_of_dna=['GVD0011', 'GVD0013', 'GVD0015'],
-    #     competent_cells='DH5alpha',
-    #     replicates=3,
-    #     volume_dna=25,
-    #     thermocycler_starting_well=0,
-    #     transfer_volume_dna=5,
-    #     tube_volume_competent_cell=150
-    # )
 
     transformation.run(protocol)

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -742,6 +742,12 @@ class Domestication(BaseAssembly):
                 self.dict_of_parts_in_thermocycler[assembly_name] = dest_well_name
                 self.dna_list_for_transformation_protocol.append(f"{part}_rep{r + 1}")
 
+                # Populate product_uri_to_wells so _export_transformation_input
+                # produces a non-empty JSON for the assembly→transformation handoff
+                if part not in self.product_uri_to_wells:
+                    self.product_uri_to_wells[part] = []
+                self.product_uri_to_wells[part].append(dest_well_name)
+
                 thermocycler_well_counter += 1
 
         return thermocycler_well_counter
@@ -1054,6 +1060,13 @@ class ManualLoopAssembly(BaseAssembly):
                 self.dict_of_parts_in_thermocycler[f"Replicate: {r + 1}, Combination: {combination}"] = dest_well_name
                 combination_name = "_".join(combination)
                 self.dna_list_for_transformation_protocol.append(f"{combination_name}_rep{r + 1}")
+
+                # Populate product_uri_to_wells so _export_transformation_input
+                # produces a non-empty JSON for the assembly→transformation handoff
+                if combination_name not in self.product_uri_to_wells:
+                    self.product_uri_to_wells[combination_name] = []
+                self.product_uri_to_wells[combination_name].append(dest_well_name)
+
                 thermocycler_well_counter += 1
 
         return thermocycler_well_counter

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -95,6 +95,7 @@ class BaseAssembly(ABC):
         self.dict_of_parts_in_temp_mod_position = {}
         self.dict_of_parts_in_thermocycler = {}
         self.dna_list_for_transformation_protocol = []
+        self.product_uri_to_wells = {}
         self.xlsx_output = None
 
         #Initialize Camera
@@ -500,28 +501,18 @@ class BaseAssembly(ABC):
         print(self.dna_list_for_transformation_protocol)
 
     # Helper methods (shared)
-    def _export_transformation_input(self, protocol, competent_cells='DH5alpha'):
+    def _export_transformation_input(self, protocol):
         """
-        Export transformation input JSON during simulation.
-
-        Args:
-            protocol: Protocol context
-            competent_cells: Competent cells to use for transformation (default: DH5alpha)
+        Export plasmid location JSON during simulation for use by transformation protocol.
+        Format: { "product_uri": ["well1", "well2", ...], ... }
         """
-
-        transformation_input = {
-            'list_of_dna': self.dna_list_for_transformation_protocol,
-            'competent_cells': competent_cells
-        }
-
         output_path = 'transformation_input.json'
         with open(output_path, 'w') as f:
-            json.dump(transformation_input, f, indent=2)
+            json.dump(self.product_uri_to_wells, f, indent=2)
 
         protocol.comment("\n" + "="*70)
-        protocol.comment(f"Generated {output_path} for next protocol")
-        protocol.comment(f"  DNA constructs: {len(self.dna_list_for_transformation_protocol)}")
-        protocol.comment(f"  Competent cells: {competent_cells}")
+        protocol.comment(f"Generated {output_path} for transformation protocol")
+        protocol.comment(f"  Products: {len(self.product_uri_to_wells)}")
         protocol.comment("="*70)
 
     def _load_reagent(self, protocol, module_labware, well_position, name, description=None,
@@ -1133,7 +1124,8 @@ class SBOLLoopAssembly(BaseAssembly):
             assembly_combo = {
                 'parts': [backbone_name] + part_names,  # Include backbone as first part
                 'enzyme': enzyme_name,
-                'product': product_name
+                'product': product_name,
+                'product_uri': assembly["Product"]
             }
             self.assembly_combinations.append(assembly_combo)
 
@@ -1224,6 +1216,13 @@ class SBOLLoopAssembly(BaseAssembly):
                 # Track assembly
                 self.dict_of_parts_in_thermocycler[f"Replicate: {r + 1}, Product: {product_name}"] = dest_well_name
                 self.dna_list_for_transformation_protocol.append(f"{product_name}_rep{r + 1}")
+
+                # Track URI -> well locations for transformation export
+                product_uri = assembly_combo['product_uri']
+                if product_uri not in self.product_uri_to_wells:
+                    self.product_uri_to_wells[product_uri] = []
+                self.product_uri_to_wells[product_uri].append(dest_well_name)
+
                 thermocycler_well_counter += 1
 
         return thermocycler_well_counter

--- a/src/pudu/generate_protocol.py
+++ b/src/pudu/generate_protocol.py
@@ -70,14 +70,18 @@ def detect_protocol_type(data) -> tuple[str, Optional[str]]:
         - protocol_type: 'assembly', 'transformation', or 'plating'
         - assembly_subtype: 'SBOL', 'Manual', 'Domestication', or None
     """
-    # Handle legacy format: bare list of assemblies
+    # Handle bare list formats
     if isinstance(data, list):
         if not data:
             raise ValueError("Empty data provided")
 
         first_item = data[0]
 
-        # Check for SBOL format
+        # Check for transformation format (Strain/Chassis/Plasmids)
+        if 'Strain' in first_item and 'Chassis' in first_item and 'Plasmids' in first_item:
+            return 'transformation', None
+
+        # Check for SBOL assembly format
         sbol_keys = {'Product', 'Backbone', 'PartsList', 'Restriction Enzyme'}
         if sbol_keys.issubset(set(first_item.keys())):
             return 'assembly', 'SBOL'
@@ -119,8 +123,8 @@ def detect_protocol_type(data) -> tuple[str, Optional[str]]:
             # Default to SBOL
             return 'assembly', 'SBOL'
 
-        # Check for transformation
-        if 'list_of_dna' in data and 'competent_cells' in data:
+        # Check for transformation (new SBOL format: list with Strain/Chassis/Plasmids)
+        if isinstance(data, list) and data and 'Strain' in data[0] and 'Chassis' in data[0] and 'Plasmids' in data[0]:
             return 'transformation', None
 
         # Check for plating
@@ -159,7 +163,7 @@ def format_python_value(value, indent_level=0):
         if all(isinstance(item, str) for item in value):
             # Simple list of strings - keep on one line if short
             formatted = ', '.join(items)
-            if len(formatted) < 80:
+            if len(formatted) < 100:
                 return f'[{formatted}]'
         # Multi-line list
         formatted_items = ',\n'.join(f'{indent}    {item}' for item in items)
@@ -177,12 +181,128 @@ def format_python_value(value, indent_level=0):
     else:
         return repr(value)
 
+def _format_annotation(ann) -> str:
+    """Format a type annotation as a clean string for display in comments."""
+    import inspect
+    if ann is inspect.Parameter.empty:
+        return ''
+    if hasattr(ann, '__name__'):
+        return ann.__name__
+    # Clean up typing generics: typing.Optional[typing.Dict] -> Optional[Dict]
+    return str(ann).replace('typing.', '')
+
+
+def generate_param_reference(protocol_type: str, class_name: str, module_str: str) -> str:
+    """
+    Generate a commented parameter reference block for the end of the protocol file.
+
+    Dynamically imports the protocol class and uses inspect to extract the full
+    __init__ signature and class docstrings, formatted as comments so users can
+    see all available parameters when making last-minute edits before running on
+    the robot.
+
+    Args:
+        protocol_type: Protocol type string (e.g. 'transformation')
+        class_name: Protocol class name (e.g. 'HeatShockTransformation')
+        module_str: Fully-qualified module path (e.g. 'pudu.transformation')
+
+    Returns:
+        Commented parameter reference block as a string, or a short error comment
+        if the class cannot be imported.
+    """
+    try:
+        import importlib
+        import inspect
+
+        mod = importlib.import_module(module_str)
+        cls = getattr(mod, class_name)
+
+        lines = []
+        lines.append("")
+        lines.append("")
+        lines.append("# " + "=" * 70)
+        lines.append(f"# PARAMETER REFERENCE — {class_name}")
+        lines.append("#")
+        lines.append("# To customize your protocol, add any of the parameters below")
+        lines.append(f"# to the {class_name}() constructor call in run() above.")
+        lines.append("# Example:  protocol_instance = " + class_name + "(")
+        lines.append(f"#               {PROTOCOL_CONFIGS[protocol_type]['data_param']}={PROTOCOL_CONFIGS[protocol_type]['data_key']},")
+        lines.append("#               replicates=3,")
+        lines.append("#               initial_tip='B1',")
+        lines.append("#           )")
+        lines.append("# " + "=" * 70)
+
+        # Collect all __init__ params walking the MRO from most-specific to base.
+        # Use an ordered dict so subclass params appear first.
+        seen_params = set()
+        mro_params = []  # list of (class, [(name, default, annotation), ...])
+
+        for klass in cls.__mro__:
+            if klass is object:
+                continue
+            try:
+                sig = inspect.signature(klass.__init__)
+            except (ValueError, TypeError):
+                continue
+
+            klass_params = []
+            for name, param in sig.parameters.items():
+                if name in ('self', 'args', 'kwargs') or name in seen_params:
+                    continue
+                seen_params.add(name)
+                default = param.default if param.default is not inspect.Parameter.empty else '(required)'
+                ann = _format_annotation(param.annotation)
+                klass_params.append((name, default, ann))
+
+            if klass_params:
+                mro_params.append((klass.__name__, klass_params))
+
+        # Build parameter table — group by class
+        if mro_params:
+            # Determine column widths across all params
+            all_param_entries = [(n, d, a) for _, params in mro_params for n, d, a in params]
+            max_name = max(len(n) for n, _, _ in all_param_entries)
+            max_type = max((len(a) for _, _, a in all_param_entries if a), default=0)
+
+            for klass_name, params in mro_params:
+                lines.append("#")
+                lines.append(f"# [{klass_name}]")
+                for name, default, ann in params:
+                    type_col = ann.ljust(max_type) if ann else ' ' * max_type
+                    default_repr = repr(default) if not isinstance(default, str) else default
+                    lines.append(f"#   {name:<{max_name}}  {type_col}  = {default_repr}")
+
+        # Append full docstrings for detailed descriptions
+        lines.append("#")
+        lines.append("# " + "-" * 70)
+        lines.append("# Full parameter descriptions:")
+
+        seen_docs: set = set()
+        for klass in cls.__mro__:
+            if klass is object:
+                continue
+            doc = inspect.getdoc(klass)
+            if not doc or doc in seen_docs:
+                continue
+            seen_docs.add(doc)
+            lines.append("#")
+            lines.append(f"# [{klass.__name__}]")
+            for doc_line in doc.split('\n'):
+                lines.append(f"# {doc_line}" if doc_line.strip() else "#")
+
+        return '\n'.join(lines)
+
+    except Exception as e:
+        return f"\n\n# (Parameter reference unavailable: {e})"
+
+
 def generate_protocol(
     protocol_data: Any,
     json_params: Optional[Dict] = None,
     metadata: Optional[Dict] = None,
     protocol_type: str = 'assembly',
-    assembly_subtype: Optional[str] = None
+    assembly_subtype: Optional[str] = None,
+    plasmid_locations: Optional[Dict] = None
 ) -> str:
     """
     Generate a complete Opentrons protocol file as a string.
@@ -193,6 +313,7 @@ def generate_protocol(
         metadata: Optional metadata dictionary (merged with defaults)
         protocol_type: Type of protocol ('assembly', 'transformation', 'plating')
         assembly_subtype: Subtype for assembly protocols ('SBOL', 'Manual', 'Domestication')
+        plasmid_locations: Optional dict mapping plasmid URIs to well locations (from assembly output)
 
     Returns:
         Complete protocol file as a string
@@ -239,10 +360,16 @@ def generate_protocol(
     lines.append("")
     lines.append("")
 
-    # Assemblies
+    # Protocol data
     lines.append(f"# Protocol data")
     lines.append(f"{data_key} = {format_python_value(actual_data)}")
     lines.append("")
+
+    # Plasmid locations (transformation only, from assembly output)
+    if plasmid_locations is not None:
+        lines.append("# Plasmid well locations from assembly protocol output")
+        lines.append(f"plasmid_locations = {format_python_value(plasmid_locations)}")
+        lines.append("")
 
     # Advanced params (if provided)
     if json_params:
@@ -265,16 +392,29 @@ def generate_protocol(
     # All protocols now use <type>_data + advanced_params pattern
     data_param = config['data_param']
 
+    # Build constructor arguments
+    constructor_args = [f"{data_param}={data_key}"]
+    if plasmid_locations is not None:
+        constructor_args.append("plasmid_locations=plasmid_locations")
     if json_params:
+        constructor_args.append("json_params=json_params")
+
+    if len(constructor_args) > 1:
         lines.append(f"    protocol_instance = {class_name}(")
-        lines.append(f"        {data_param}={data_key},")
-        lines.append("        json_params=json_params")
+        for i, arg in enumerate(constructor_args):
+            comma = "," if i < len(constructor_args) - 1 else ""
+            lines.append(f"        {arg}{comma}")
         lines.append("    )")
     else:
-        lines.append(f"    protocol_instance = {class_name}({data_param}={data_key})")
+        lines.append(f"    protocol_instance = {class_name}({constructor_args[0]})")
 
     lines.append("    protocol_instance.run(protocol)")
     lines.append("")
+
+    # Parameter reference block — appended as comments for last-minute editing
+    param_ref = generate_param_reference(protocol_type, class_name, module)
+    if param_ref:
+        lines.append(param_ref)
 
     return '\n'.join(lines)
 
@@ -288,8 +428,11 @@ Examples:
   # Generate assembly protocol (auto-detect type)
   python -m pudu.generate_protocol data.json params.json -o protocol.py --protocol-type assembly
 
-  # Generate transformation protocol
-  python -m pudu.generate_protocol transformation.json params.json -o protocol.py --protocol-type transformation
+  # Generate transformation protocol with assembly output
+  python -m pudu.generate_protocol synbiosuite.json params.json -o protocol.py --protocol-type transformation --plasmid-locations transformation_input.json
+
+  # Generate transformation protocol without prior assembly (manual input)
+  python -m pudu.generate_protocol synbiosuite.json params.json -o protocol.py --protocol-type transformation
 
   # Generate plating protocol
   python -m pudu.generate_protocol plating.json -o protocol.py --protocol-type plating
@@ -338,6 +481,13 @@ Examples:
     )
 
     parser.add_argument(
+        '--plasmid-locations',
+        type=Path,
+        default=None,
+        help='Path to plasmid locations JSON file from assembly simulation (transformation protocols only)'
+    )
+
+    parser.add_argument(
         '--metadata',
         type=Path,
         default=None,
@@ -368,6 +518,19 @@ Examples:
             sys.exit(1)
         except json.JSONDecodeError as e:
             print(f"Error: Invalid JSON in advanced params file: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Load plasmid locations if provided
+    plasmid_locations = None
+    if args.plasmid_locations:
+        try:
+            with open(args.plasmid_locations, 'r') as f:
+                plasmid_locations = json.load(f)
+        except FileNotFoundError:
+            print(f"Error: Plasmid locations file not found: {args.plasmid_locations}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in plasmid locations file: {e}", file=sys.stderr)
             sys.exit(1)
 
     # Load metadata if provided
@@ -415,7 +578,8 @@ Examples:
             json_params=json_params,
             metadata=metadata,
             protocol_type=protocol_type,
-            assembly_subtype=assembly_subtype
+            assembly_subtype=assembly_subtype,
+            plasmid_locations=plasmid_locations
         )
     except Exception as e:
         print(f"Error generating protocol: {e}", file=sys.stderr)

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -70,6 +70,12 @@ class Transformation():
     water_testing : bool
         If True, uses water in place of competent cells and recovery media during
         simulation/testing runs. By default, False.
+    initial_tip_p20 : str, optional
+        Well name of the first tip to use from the p20 tip rack (e.g. 'B1').
+        If None, starts from the first available tip. By default, None.
+    initial_tip_p300 : str, optional
+        Well name of the first tip to use from the p300 tip rack (e.g. 'C3').
+        If None, starts from the first available tip. By default, None.
     '''
     def __init__(self,
                  transformation_data: Optional[List] = None,
@@ -96,6 +102,8 @@ class Transformation():
                  dispense_rate:float = 1,
                  initial_dna_well:int = 0,
                  water_testing:bool = False,
+                 initial_tip_p20:Optional[str] = None,
+                 initial_tip_p300:Optional[str] = None,
                  **kwargs
                  ):
 
@@ -120,7 +128,9 @@ class Transformation():
             'aspiration_rate': aspiration_rate,
             'dispense_rate': dispense_rate,
             'initial_dna_well': initial_dna_well,
-            'water_testing': water_testing
+            'water_testing': water_testing,
+            'initial_tip_p20': initial_tip_p20,
+            'initial_tip_p300': initial_tip_p300
         }
         kwargs_params.update(kwargs)
 
@@ -163,6 +173,8 @@ class Transformation():
         self.dispense_rate = self._merged_params['dispense_rate']
         self.initial_dna_well = self._merged_params['initial_dna_well']
         self.water_testing = self._merged_params['water_testing']
+        self.initial_tip_p20 = self._merged_params['initial_tip_p20']
+        self.initial_tip_p300 = self._merged_params['initial_tip_p300']
 
     def _extract_name_from_uri(self, uri: str) -> str:
         """Extract name from SBOL URI"""
@@ -276,6 +288,8 @@ class Transformation():
             'dispense_rate': 1,
             'initial_dna_well': 0,
             'water_testing': False,
+            'initial_tip_p20': None,
+            'initial_tip_p300': None,
             # HeatShockTransformation-specific parameters
             'transfer_volume_dna': 2,
             'transfer_volume_competent_cell': 20,
@@ -507,7 +521,11 @@ class HeatShockTransformation(Transformation):
         tiprack_p200 = protocol.load_labware(self.tiprack_p200_labware, self.tiprack_p200_position)
         # Load the pipette
         pipette_p20 = protocol.load_instrument(self.pipette_p20, self.pipette_p20_position, tip_racks=[tiprack_p20])
+        if self.initial_tip_p20:
+            pipette_p20.starting_tip = tiprack_p20[self.initial_tip_p20]
         pipette_p300 = protocol.load_instrument(self.pipette_p300, self.pipette_p300_position, tip_racks=[tiprack_p200])
+        if self.initial_tip_p300:
+            pipette_p300.starting_tip = tiprack_p200[self.initial_tip_p300]
         #Validate protocol
         self._validate_protocol(protocol, alumblock)
 

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -594,7 +594,21 @@ class HeatShockTransformation(Transformation):
         # Number of location replicates per strain (assembly replicates of the same plasmid in plate,
         # always 1 for temp module since plasmids are in a single sequential well)
         if self.plasmid_locations is not None:
-            self.location_replicates = len(next(iter(self.plasmid_locations.values())))
+            # Build name→URI map for the plasmids referenced in this protocol
+            name_to_uri = {self._extract_name_from_uri(uri): uri for uri in self.plasmid_locations}
+            well_counts = {}
+            for plasmid_name in self.all_plasmids:
+                if plasmid_name in name_to_uri:
+                    uri = name_to_uri[plasmid_name]
+                    well_counts[plasmid_name] = len(self.plasmid_locations[uri])
+            unique_counts = set(well_counts.values())
+            if len(unique_counts) > 1:
+                detail = ', '.join(f'{name}: {count} wells' for name, count in well_counts.items())
+                raise ValueError(
+                    f"plasmid_locations has inconsistent replicate counts across plasmids — "
+                    f"all plasmids must have the same number of wells. Found: {detail}"
+                )
+            self.location_replicates = unique_counts.pop() if unique_counts else 1
         else:
             self.location_replicates = 1
 

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -685,9 +685,13 @@ class HeatShockTransformation(Transformation):
                                  f'{self.media_tubes_needed} tubes with media.'
                                  f'Please modify the protocol and try again.')
         else:
-            # DNA, cells, and media all on the temp module
-            if total_plasmid_wells + total_competent_cell_tubes + self.media_tubes_needed > module_wells:
+            # DNA, cells, and media all on the temp module.
+            # Loading starts at initial_dna_well, so the offset must be included
+            # in the capacity check — otherwise a non-zero offset can push the
+            # final reagent past the last well even when raw counts look fine.
+            if self.initial_dna_well + total_plasmid_wells + total_competent_cell_tubes + self.media_tubes_needed > module_wells:
                 raise ValueError(f'The number of reagents is more than {module_wells}.'
+                                 f'DNA starts at well {self.initial_dna_well}.'
                                  f'There are {total_plasmid_wells} plasmid wells.'
                                  f'{total_competent_cell_tubes} tubes with competent cells ({self.competent_cell_tubes_by_chassis}).'
                                  f'{self.media_tubes_needed} tubes with media.'

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -76,6 +76,13 @@ class Transformation():
     initial_tip_p300 : str, optional
         Well name of the first tip to use from the p300 tip rack (e.g. 'C3').
         If None, starts from the first available tip. By default, None.
+    tube_rack_labware : str
+        Labware type for the tube rack that holds competent cells and recovery
+        media. Moving these off the temperature module frees the entire aluminum
+        block for DNA plasmids, maximising unique constructs per run.
+        By default, 'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap'.
+    tube_rack_position : str
+        Deck slot for the tube rack. By default, '3'.
     '''
     def __init__(self,
                  transformation_data: Optional[List] = None,
@@ -104,6 +111,8 @@ class Transformation():
                  water_testing:bool = False,
                  initial_tip_p20:Optional[str] = None,
                  initial_tip_p300:Optional[str] = None,
+                 tube_rack_labware:str = 'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap',
+                 tube_rack_position:str = '3',
                  **kwargs
                  ):
 
@@ -130,7 +139,9 @@ class Transformation():
             'initial_dna_well': initial_dna_well,
             'water_testing': water_testing,
             'initial_tip_p20': initial_tip_p20,
-            'initial_tip_p300': initial_tip_p300
+            'initial_tip_p300': initial_tip_p300,
+            'tube_rack_labware': tube_rack_labware,
+            'tube_rack_position': tube_rack_position
         }
         kwargs_params.update(kwargs)
 
@@ -175,6 +186,8 @@ class Transformation():
         self.water_testing = self._merged_params['water_testing']
         self.initial_tip_p20 = self._merged_params['initial_tip_p20']
         self.initial_tip_p300 = self._merged_params['initial_tip_p300']
+        self.tube_rack_labware = self._merged_params['tube_rack_labware']
+        self.tube_rack_position = self._merged_params['tube_rack_position']
 
     def _extract_name_from_uri(self, uri: str) -> str:
         """Extract name from SBOL URI"""
@@ -314,6 +327,8 @@ class Transformation():
             'water_testing': False,
             'initial_tip_p20': None,
             'initial_tip_p300': None,
+            'tube_rack_labware': 'opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap',
+            'tube_rack_position': '3',
             # HeatShockTransformation-specific parameters
             'transfer_volume_dna': 2,
             'transfer_volume_competent_cell': 20,
@@ -470,6 +485,7 @@ class HeatShockTransformation(Transformation):
         self.dict_of_parts_in_temp_mod_position = {}
         self.dict_of_parts_in_thermocycler = {}
         self.dict_of_parts_in_dna_plate = {}
+        self.dict_of_parts_in_tube_rack = {}
         self.plasmid_name_to_wells = {}  # plasmid name -> [well_obj, ...], populated during loading
 
     def _export_plating_input(self, protocol):
@@ -540,6 +556,8 @@ class HeatShockTransformation(Transformation):
         #If using the 96-well pcr plate as a dna construct source
         if self.use_dna_96plate:
             dna_plate = protocol.load_labware(self.dna_plate, self.dna_plate_position)
+        # Load the tube rack for competent cells and recovery media
+        tube_rack = protocol.load_labware(self.tube_rack_labware, self.tube_rack_position)
         # Load the tiprack
         tiprack_p20 = protocol.load_labware(self.tiprack_p20_labware, self.tiprack_p20_position)
         tiprack_p200 = protocol.load_labware(self.tiprack_p200_labware, self.tiprack_p200_position)
@@ -551,13 +569,13 @@ class HeatShockTransformation(Transformation):
         if self.initial_tip_p300:
             pipette_p300.starting_tip = tiprack_p200[self.initial_tip_p300]
         #Validate protocol
-        self._validate_protocol(protocol, alumblock)
+        self._validate_protocol(protocol, alumblock, tube_rack)
 
         #Load Reagents (also populates self.plasmid_name_to_wells)
         if self.use_dna_96plate:
-            competent_cell_wells_by_chassis, media_wells = self._load_reagents_96plate(protocol, dna_plate, alumblock)
+            competent_cell_wells_by_chassis, media_wells = self._load_reagents_96plate(protocol, dna_plate, alumblock, tube_rack)
         else:
-            competent_cell_wells_by_chassis, media_wells = self._load_reagents_temp_module(protocol, alumblock)
+            competent_cell_wells_by_chassis, media_wells = self._load_reagents_temp_module(protocol, alumblock, tube_rack)
 
         #Set Temperature module and Thermocycler module to 4
         thermocycler_module.open_lid()
@@ -607,36 +625,41 @@ class HeatShockTransformation(Transformation):
                 protocol.comment(f"Could not export plating input: {e}")
 
         # output
-        print('Strain and media tube in temp_mod')
-        print(self.dict_of_parts_in_temp_mod_position)
         if self.use_dna_96plate:
-            print('DNA constructs in DNA plate (slot 2)')
+            print('DNA constructs in DNA plate')
             print(self.dict_of_parts_in_dna_plate)
+        else:
+            print('DNA plasmids in temperature module')
+            print(self.dict_of_parts_in_temp_mod_position)
+        print('Competent cells and media in tube rack')
+        print(self.dict_of_parts_in_tube_rack)
         print('Genetically modified organisms in thermocycler')
         print(self.dict_of_parts_in_thermocycler)
 
-    def _validate_protocol(self, protocol, labware):
+    def _validate_protocol(self, protocol, labware, tube_rack=None):
         """
         Validate protocol requirements and compute all derived counts used throughout run().
         Sets: self.location_replicates, self.total_transformations,
               self.transformations_per_cell_tube, self.competent_cell_tubes_by_chassis,
               self.reactions_by_chassis, self.transformations_per_media_tube,
               self.media_tubes_needed.
-        Raises ValueError if reagents exceed available alumblock wells.
+
+        Competent cells and recovery media always go onto the tube rack.
+        The aluminum block (labware) is used only for DNA plasmids when
+        use_dna_96plate=False. This maximises the number of unique constructs
+        that can be transformed in a single run.
+
+        Raises ValueError if reagents exceed available wells on either labware.
         """
-        #Number of available wells to load into
         module_wells = len(labware.wells())
+        tube_rack_wells = len(tube_rack.wells()) if tube_rack is not None else 24
 
-        #Number of strains to transform
         total_strains = len(self.transformations)
-
-        #Number of total plasmid wells needed (one well per unique plasmid)
         total_plasmid_wells = len(self.all_plasmids)
 
-        # Number of location replicates per strain (assembly replicates of the same plasmid in plate,
-        # always 1 for temp module since plasmids are in a single sequential well)
+        # Number of location replicates per strain (assembly replicates of the same
+        # plasmid in the 96-well plate; always 1 when plasmids are on the temp module)
         if self.plasmid_locations is not None:
-            # Build name→URI map for the plasmids referenced in this protocol
             name_to_uri = {self._extract_name_from_uri(uri): uri for uri in self.plasmid_locations}
             well_counts = {}
             for plasmid_name in self.all_plasmids:
@@ -654,17 +677,15 @@ class HeatShockTransformation(Transformation):
         else:
             self.location_replicates = 1
 
-        #Total transformation reactions
         self.total_transformations = total_strains * self.location_replicates * self.replicates
 
-        #Calculate competent cell tubes needed per chassis type
+        # Calculate competent cell tubes needed per chassis
         self.transformations_per_cell_tube = self.tube_volume_competent_cell // self.transfer_volume_competent_cell
         self.competent_cell_tubes_by_chassis = {}
         self.reactions_by_chassis = {}
         total_competent_cell_tubes = 0
 
         for chassis in self.all_chassis:
-            # Count how many transformations use this chassis
             transformations_for_chassis = sum(1 for t in self.transformations if t['chassis'] == chassis)
             reactions_for_chassis = transformations_for_chassis * self.location_replicates * self.replicates
             self.reactions_by_chassis[chassis] = reactions_for_chassis
@@ -672,43 +693,42 @@ class HeatShockTransformation(Transformation):
             self.competent_cell_tubes_by_chassis[chassis] = tubes_needed
             total_competent_cell_tubes += tubes_needed
 
-        #Number of tubes with media to be used
         self.transformations_per_media_tube = self.tube_volume_recovery_media // self.transfer_volume_recovery_media
         self.media_tubes_needed = (self.total_transformations + self.transformations_per_media_tube - 1) // self.transformations_per_media_tube
 
-        #Validate wells
-        if self.use_dna_96plate:
-            # DNA is on a separate plate, only cells and media on the temp module
-            if total_competent_cell_tubes + self.media_tubes_needed > module_wells:
-                raise ValueError(f'The number of reagents is more than {module_wells}.'
-                                 f'There are {total_competent_cell_tubes} tubes with competent cells ({self.competent_cell_tubes_by_chassis}).'
-                                 f'{self.media_tubes_needed} tubes with media.'
-                                 f'Please modify the protocol and try again.')
-        else:
-            # DNA, cells, and media all on the temp module.
-            # Loading starts at initial_dna_well, so the offset must be included
-            # in the capacity check — otherwise a non-zero offset can push the
-            # final reagent past the last well even when raw counts look fine.
-            if self.initial_dna_well + total_plasmid_wells + total_competent_cell_tubes + self.media_tubes_needed > module_wells:
-                raise ValueError(f'The number of reagents is more than {module_wells}.'
-                                 f'DNA starts at well {self.initial_dna_well}.'
-                                 f'There are {total_plasmid_wells} plasmid wells.'
-                                 f'{total_competent_cell_tubes} tubes with competent cells ({self.competent_cell_tubes_by_chassis}).'
-                                 f'{self.media_tubes_needed} tubes with media.'
-                                 f'Please modify the protocol and try again.')
+        # Tube rack capacity: cells and media always live here
+        if total_competent_cell_tubes + self.media_tubes_needed > tube_rack_wells:
+            raise ValueError(
+                f'The number of reagent tubes is more than the tube rack capacity of {tube_rack_wells} wells. '
+                f'There are {total_competent_cell_tubes} competent cell tubes ({self.competent_cell_tubes_by_chassis}) '
+                f'and {self.media_tubes_needed} media tubes. '
+                f'Please modify the protocol and try again.'
+            )
+
+        # Temperature module capacity: DNA plasmids only (when not using 96-well plate).
+        # Loading starts at initial_dna_well so the offset is included in the check.
+        if not self.use_dna_96plate:
+            if self.initial_dna_well + total_plasmid_wells > module_wells:
+                raise ValueError(
+                    f'The number of plasmids requires more than {module_wells} temperature module wells. '
+                    f'DNA starts at well {self.initial_dna_well} with {total_plasmid_wells} unique plasmids '
+                    f'({self.initial_dna_well + total_plasmid_wells} wells needed). '
+                    f'Please modify the protocol and try again.'
+                )
 
 
-    def _load_reagents_96plate(self, protocol, dna_plate, alumblock):
+    def _load_reagents_96plate(self, protocol, dna_plate, alumblock, tube_rack):
         """
         Load all reagents for the 96-well plate workflow (plasmid_locations provided).
         DNA constructs are loaded from the assembly output plate at their fixed positions —
         populates self.plasmid_name_to_wells. Competent cells and media are loaded
-        sequentially onto the alumblock starting at well 0.
+        onto the tube rack (not the alumblock), leaving the alumblock entirely free.
 
         Parameters:
         - protocol: Protocol context
         - dna_plate: 96-well plate labware object (slot 2)
-        - alumblock: Temperature module labware object
+        - alumblock: Temperature module labware object (unused in this path)
+        - tube_rack: Tube rack labware object for competent cells and recovery media
 
         Returns:
         - competent_cell_wells_by_chassis: dict mapping chassis name to list of well objects
@@ -718,19 +738,20 @@ class HeatShockTransformation(Transformation):
         # Populates self.plasmid_name_to_wells
         self._load_dna_into_dna_plate(protocol, dna_plate)
 
-        # Load competent cells for each chassis onto alumblock
+        # Load competent cells and media onto tube rack starting at well 0
         competent_cell_wells_by_chassis = {}
         current_well = 0
         for chassis in self.all_chassis:
             tubes_needed = self.competent_cell_tubes_by_chassis[chassis]
-            wells = self._load_reagents(protocol, alumblock, self.tube_volume_competent_cell,
-                                        f"Competent Cell {chassis}", tubes_needed, initial_well=current_well)
+            wells = self._load_reagents(protocol, tube_rack, self.tube_volume_competent_cell,
+                                        f"Competent Cell {chassis}", tubes_needed, initial_well=current_well,
+                                        tracking_dict=self.dict_of_parts_in_tube_rack)
             competent_cell_wells_by_chassis[chassis] = wells
             current_well += tubes_needed
 
-        # Load media onto alumblock
-        media_wells = self._load_reagents(protocol, alumblock, self.tube_volume_recovery_media,
-                                          "Media", self.media_tubes_needed, initial_well=current_well)
+        media_wells = self._load_reagents(protocol, tube_rack, self.tube_volume_recovery_media,
+                                          "Media", self.media_tubes_needed, initial_well=current_well,
+                                          tracking_dict=self.dict_of_parts_in_tube_rack)
 
         return competent_cell_wells_by_chassis, media_wells
 
@@ -768,16 +789,18 @@ class HeatShockTransformation(Transformation):
             self.dict_of_parts_in_dna_plate[construct_name] = well_names
             current_color += 1
 
-    def _load_reagents_temp_module(self, protocol, alumblock):
+    def _load_reagents_temp_module(self, protocol, alumblock, tube_rack):
         """
         Load all reagents for the temp module workflow (no plasmid_locations).
-        DNA constructs are loaded sequentially starting at initial_dna_well —
-        populates self.plasmid_name_to_wells. Competent cells and media follow
-        sequentially on the same alumblock.
+        DNA constructs are loaded sequentially onto the alumblock starting at
+        initial_dna_well — populates self.plasmid_name_to_wells. Competent cells
+        and media are loaded onto the tube rack (not the alumblock), so the entire
+        alumblock is available for DNA plasmids.
 
         Parameters:
         - protocol: Protocol context
-        - alumblock: Temperature module labware object
+        - alumblock: Temperature module labware object (DNA plasmids only)
+        - tube_rack: Tube rack labware object for competent cells and recovery media
 
         Returns:
         - competent_cell_wells_by_chassis: dict mapping chassis name to list of well objects
@@ -787,19 +810,20 @@ class HeatShockTransformation(Transformation):
         # Populates self.plasmid_name_to_wells
         self._load_dna_into_temp_module(protocol, alumblock)
 
-        # Load competent cells for each chassis, starting after the DNA wells
+        # Load competent cells and media onto tube rack starting at well 0
         competent_cell_wells_by_chassis = {}
-        current_well = self.initial_dna_well + len(self.all_plasmids)
+        current_well = 0
         for chassis in self.all_chassis:
             tubes_needed = self.competent_cell_tubes_by_chassis[chassis]
-            wells = self._load_reagents(protocol, alumblock, self.tube_volume_competent_cell,
-                                        f"Competent Cell {chassis}", tubes_needed, initial_well=current_well)
+            wells = self._load_reagents(protocol, tube_rack, self.tube_volume_competent_cell,
+                                        f"Competent Cell {chassis}", tubes_needed, initial_well=current_well,
+                                        tracking_dict=self.dict_of_parts_in_tube_rack)
             competent_cell_wells_by_chassis[chassis] = wells
             current_well += tubes_needed
 
-        # Load media onto alumblock after competent cells
-        media_wells = self._load_reagents(protocol, alumblock, self.tube_volume_recovery_media,
-                                          "Media", self.media_tubes_needed, initial_well=current_well)
+        media_wells = self._load_reagents(protocol, tube_rack, self.tube_volume_recovery_media,
+                                          "Media", self.media_tubes_needed, initial_well=current_well,
+                                          tracking_dict=self.dict_of_parts_in_tube_rack)
 
         return competent_cell_wells_by_chassis, media_wells
 
@@ -827,11 +851,11 @@ class HeatShockTransformation(Transformation):
             self.dict_of_parts_in_temp_mod_position[construct_name] = well.well_name
             current_color += 1
 
-    def _load_reagents(self, protocol, labware, volume, reagent_name, tube_count, initial_well=0, color_index=None):
+    def _load_reagents(self, protocol, labware, volume, reagent_name, tube_count, initial_well=0, color_index=None, tracking_dict=None):
         """
         Load multiple tubes of the same reagent type onto a labware object.
         Tubes are named {reagent_name}_1, {reagent_name}_2, etc. and tracked
-        in self.dict_of_parts_in_temp_mod_position.
+        in tracking_dict (defaults to self.dict_of_parts_in_temp_mod_position).
 
         Parameters:
         - protocol: Protocol context
@@ -841,10 +865,13 @@ class HeatShockTransformation(Transformation):
         - tube_count: Number of tubes to load
         - initial_well: Starting well index on the labware
         - color_index: Starting color index for Opentrons UI (cycles through colors list)
+        - tracking_dict: Dict to record {name: well_name}; defaults to dict_of_parts_in_temp_mod_position
 
         Returns:
         - List of well objects in order
         """
+        if tracking_dict is None:
+            tracking_dict = self.dict_of_parts_in_temp_mod_position
         wells = []
         current_color = color_index if color_index is not None else 0
         for i in range(tube_count):
@@ -858,7 +885,7 @@ class HeatShockTransformation(Transformation):
             )
 
             well.load_liquid(liquid, volume=volume)
-            self.dict_of_parts_in_temp_mod_position[name] = well.well_name
+            tracking_dict[name] = well.well_name
             current_color += 1
         return wells
 

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -210,6 +210,8 @@ class Transformation():
         transformations = []
         all_plasmids_set = set()
         all_chassis_set = set()
+        seen_plasmid_names = {}  # name -> URI; detects two different URIs that collapse to the same name
+        seen_chassis_names = {}  # name -> URI; same check for chassis
 
         for idx, transformation in enumerate(transformation_data):
             # Validate required fields
@@ -226,9 +228,31 @@ class Transformation():
 
             # Extract names from URIs
             strain_name = self._extract_name_from_uri(transformation['Strain'])
-            chassis_name = self._extract_name_from_uri(transformation['Chassis'])
+            chassis_uri = transformation['Chassis']
+            chassis_name = self._extract_name_from_uri(chassis_uri)
             plasmid_uris = transformation['Plasmids']
             plasmid_names = [self._extract_name_from_uri(p) for p in plasmid_uris]
+
+            # Chassis collision check: same name from two different URIs is ambiguous
+            if chassis_name in seen_chassis_names and seen_chassis_names[chassis_name] != chassis_uri:
+                raise ValueError(
+                    f"Transformation {idx}: two chassis URIs extract to the same name "
+                    f"'{chassis_name}': '{seen_chassis_names[chassis_name]}' and '{chassis_uri}'. "
+                    f"Rename one URI to avoid ambiguity."
+                )
+            seen_chassis_names[chassis_name] = chassis_uri
+
+            # Plasmid collision check: same name from two different URIs would cause
+            # silent well lookup errors in _load_dna_into_dna_plate.
+            # The same URI appearing multiple times (shared plasmid) is fine.
+            for plasmid_uri, plasmid_name in zip(plasmid_uris, plasmid_names):
+                if plasmid_name in seen_plasmid_names and seen_plasmid_names[plasmid_name] != plasmid_uri:
+                    raise ValueError(
+                        f"Transformation {idx}: two plasmid URIs extract to the same name "
+                        f"'{plasmid_name}': '{seen_plasmid_names[plasmid_name]}' and '{plasmid_uri}'. "
+                        f"Rename one URI to avoid ambiguity."
+                    )
+                seen_plasmid_names[plasmid_name] = plasmid_uri
 
             # If plasmid_locations provided, validate all plasmid URIs are present
             if self.plasmid_locations is not None:

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -5,47 +5,76 @@ from pudu.utils import colors
 
 class Transformation():
     '''
-    Creates a protocol for automated transformation.
+    Base class for automated transformation protocols on the Opentrons OT-2.
+
+    Handles loading transformation data, validating parameters, and providing
+    shared utilities used by all transformation subclasses. Subclasses implement
+    the specific thermocycler workflow (e.g. heat shock).
 
     Attributes
     ----------
     volume_dna : float
-        The volume DNA in microliters. By default, 2 microliters. We suggest 2 microliters for extracted plasmid and 5 microliters for PCR products.
-    volume_competent_cells : float
-        The volume of the competent cells in microliters. By default, 50 microliters.
-    volume_recovery_media : float
-        The volume of recovery media in microliters. By default, 100 microliters.
+        Volume of DNA loaded into each source well, in microliters. By default,
+        20 microliters. We suggest 2 µL for extracted plasmid and 5 µL for PCR
+        products when setting transfer_volume_dna in the subclass.
     replicates : int
-        The number of replicates of the assembly reaction. By default, 2.
+        Number of transformation replicates per strain per assembly location.
+        By default, 2.
     thermocycler_starting_well : int
-        The starting well of the thermocycler module. By default, 0.
+        Zero-indexed starting well in the thermocycler plate. By default, 0 (well A1).
     thermocycler_labware : str
-        The labware type of the thermocycler module. By default, 'nest_96_wellplate_100ul_pcr_full_skirt'.
-    thermocycler_slots : list
-        The slots of the thermocycler module. By default, [7, 8, 10, 11].
+        Labware type for the thermocycler plate.
+        By default, 'nest_96_wellplate_100ul_pcr_full_skirt'.
     temperature_module_labware : str
-        The labware type of the temperature module. By default, 'opentrons_24_aluminumblock_nest_1.5ml_snapcap'.
-    temperature_module_position : int
-        The deck position of the temperature module. By default, 1.
-    tiprack_labware : str
-        The labware type of the tiprack. By default, 'opentrons_96_tiprack_20ul'.
-    tiprack_position : int
-        The deck position of the tiprack. By default, 9.
-    pipette_type : str
-        The type of pipette. By default, 'p20_single_gen2'.
-    pipette_mount : str
-        The mount of the pipette. By default, 'left'.
+        Labware type for the aluminum block on the temperature module.
+        By default, 'opentrons_24_aluminumblock_nest_1.5ml_snapcap'.
+    temperature_module_position : str
+        Deck slot for the temperature module. By default, '1'.
+    dna_plate : str
+        Labware type for the 96-well DNA source plate (used when use_dna_96plate=True).
+        By default, 'nest_96_wellplate_100ul_pcr_full_skirt'.
+    dna_plate_position : str
+        Deck slot for the 96-well DNA source plate. By default, '2'.
+    use_dna_96plate : bool
+        If True, DNA is sourced from a 96-well plate at fixed positions given by
+        plasmid_locations. Automatically set to True when plasmid_locations is
+        provided. By default, False.
+    tiprack_p20_labware : str
+        Labware type for the p20 tip rack. By default, 'opentrons_96_tiprack_20ul'.
+    tiprack_p20_position : str
+        Deck slot for the p20 tip rack. By default, '9'.
+    tiprack_p200_labware : str
+        Labware type for the p200 tip rack.
+        By default, 'opentrons_96_filtertiprack_200ul'.
+    tiprack_p200_position : str
+        Deck slot for the p200 tip rack. By default, '6'.
+    pipette_p20 : str
+        Pipette model for the p20 single-channel. By default, 'p20_single_gen2'.
+    pipette_p20_position : str
+        Mount for the p20 pipette ('left' or 'right'). By default, 'left'.
+    pipette_p300 : str
+        Pipette model for the p300 single-channel. By default, 'p300_single_gen2'.
+    pipette_p300_position : str
+        Mount for the p300 pipette ('left' or 'right'). By default, 'right'.
     aspiration_rate : float
-        The rate of aspiration in microliters per second. By default, 0.5 microliters per second.
+        Relative aspiration speed as a fraction of the pipette's maximum flow
+        rate, where 1.0 is full speed and 0.5 is half speed. Lower values
+        reduce bubble formation. By default, 0.5.
     dispense_rate : float
-        The rate of dispense in microliters per second. By default, 1 microliter per second.
+        Relative dispense speed as a fraction of the pipette's maximum flow
+        rate, where 1.0 is full speed. By default, 1.0.
+    initial_dna_well : int
+        Zero-indexed starting well for DNA tubes on the aluminum block (used when
+        use_dna_96plate=False). By default, 0.
+    water_testing : bool
+        If True, uses water in place of competent cells and recovery media during
+        simulation/testing runs. By default, False.
     '''
     def __init__(self,
-                 transformation_data: Optional[Dict] = None,
+                 transformation_data: Optional[List] = None,
+                 plasmid_locations: Optional[Dict] = None,
                  json_params: Optional[Dict] = None,
-                 list_of_dna:Optional[List] = None,
                  volume_dna:float = 20,
-                 competent_cells: Optional[str] = None,
                  replicates:int=2,
                  thermocycler_starting_well:int = 0,
                  thermocycler_labware:str = "nest_96_wellplate_100ul_pcr_full_skirt",
@@ -70,9 +99,7 @@ class Transformation():
                  ):
 
         kwargs_params = {
-            'list_of_dna': list_of_dna,
             'volume_dna': volume_dna,
-            'competent_cells': competent_cells,
             'replicates': replicates,
             'thermocycler_starting_well': thermocycler_starting_well,
             'thermocycler_labware': thermocycler_labware,
@@ -98,17 +125,15 @@ class Transformation():
 
         self._merged_params = self._merge_params(transformation_data, json_params, kwargs_params)
 
-        if self._merged_params.get('list_of_dna') is None:
-            raise ValueError(
-                "Must input a list of DNA strings (either via transformation_data, advanced_params, or list_of_dna parameter)")
-        if self._merged_params.get('competent_cells') is None:
-            raise ValueError(
-                "Must input a competent cell string (either via transformation_data, advanced_params, or competent_cells parameter)")
+        # Parse and validate transformation data (new SBOL format)
+        if transformation_data is None:
+            raise ValueError("Must provide transformation_data as a list of transformation dictionaries")
+
+        self.plasmid_locations = plasmid_locations  # URI -> [well, well, ...] from assembly output
+        self.transformations, self.all_plasmids, self.all_chassis = self._parse_transformation_data(transformation_data)
 
         # Set all attributes from merged parameters
-        self.list_of_dna = self._merged_params['list_of_dna']
         self.volume_dna = self._merged_params['volume_dna']
-        self.competent_cells = self._merged_params['competent_cells']
         self.replicates = self._merged_params['replicates']
         self.thermocycler_starting_well = self._merged_params['thermocycler_starting_well']
         self.thermocycler_labware = self._merged_params['thermocycler_labware']
@@ -117,6 +142,14 @@ class Transformation():
         self.dna_plate = self._merged_params['dna_plate']
         self.dna_plate_position = self._merged_params['dna_plate_position']
         self.use_dna_96plate = self._merged_params['use_dna_96plate']
+
+        # 96-well plate and plasmid_locations are always paired:
+        # positions on the plate are fixed by the assembly run and cannot be assumed sequential
+        if self.use_dna_96plate and self.plasmid_locations is None:
+            raise ValueError("plasmid_locations must be provided when use_dna_96plate=True. "
+                             "Well positions on the assembly plate are fixed and cannot be assumed sequential.")
+        if self.plasmid_locations is not None:
+            self.use_dna_96plate = True
         self.tiprack_p20_labware = self._merged_params['tiprack_p20_labware']
         self.tiprack_p20_position = self._merged_params['tiprack_p20_position']
         self.tiprack_p200_labware = self._merged_params['tiprack_p200_labware']
@@ -129,6 +162,81 @@ class Transformation():
         self.dispense_rate = self._merged_params['dispense_rate']
         self.initial_dna_well = self._merged_params['initial_dna_well']
         self.water_testing = self._merged_params['water_testing']
+
+    def _extract_name_from_uri(self, uri: str) -> str:
+        """Extract name from SBOL URI"""
+        if '/' in uri:
+            name_with_version = uri.split('/')[-2]
+            if '/' in name_with_version:
+                return name_with_version.split('/')[0]
+            return name_with_version
+        return uri
+
+    def _parse_transformation_data(self, transformation_data):
+        """
+        Parse new SBOL-style transformation data format.
+
+        Expected format:
+        [
+          {
+            "Strain": "https://SBOL2Build.org/composite_1/1",
+            "Chassis": "https://sbolcanvas.org/DH5alpha/1",
+            "Plasmids": ["https://...", "https://..."]
+          },
+          ...
+        ]
+
+        Returns:
+            transformations: List of dicts with strain, chassis, and plasmids
+            all_plasmids: Flat list of all unique plasmids
+            all_chassis: List of unique chassis types
+        """
+        if not isinstance(transformation_data, list):
+            raise ValueError("transformation_data must be a list of transformation dictionaries")
+
+        transformations = []
+        all_plasmids_set = set()
+        all_chassis_set = set()
+
+        for idx, transformation in enumerate(transformation_data):
+            # Validate required fields
+            if 'Strain' not in transformation:
+                raise ValueError(f"Transformation {idx} missing 'Strain' field")
+            if 'Chassis' not in transformation:
+                raise ValueError(f"Transformation {idx} missing 'Chassis' field")
+            if 'Plasmids' not in transformation:
+                raise ValueError(f"Transformation {idx} missing 'Plasmids' field")
+            if not isinstance(transformation['Plasmids'], list):
+                raise ValueError(f"Transformation {idx}: 'Plasmids' must be a list")
+            if len(transformation['Plasmids']) == 0:
+                raise ValueError(f"Transformation {idx}: 'Plasmids' list cannot be empty")
+
+            # Extract names from URIs
+            strain_name = self._extract_name_from_uri(transformation['Strain'])
+            chassis_name = self._extract_name_from_uri(transformation['Chassis'])
+            plasmid_uris = transformation['Plasmids']
+            plasmid_names = [self._extract_name_from_uri(p) for p in plasmid_uris]
+
+            # If plasmid_locations provided, validate all plasmid URIs are present
+            if self.plasmid_locations is not None:
+                for uri in plasmid_uris:
+                    if uri not in self.plasmid_locations:
+                        raise ValueError(
+                            f"Plasmid URI '{uri}' not found in plasmid_locations. "
+                            f"Available URIs: {list(self.plasmid_locations.keys())}"
+                        )
+
+            transformations.append({
+                'strain': strain_name,
+                'chassis': chassis_name,
+                'plasmids': plasmid_names,
+                'plasmid_uris': plasmid_uris
+            })
+
+            all_plasmids_set.update(plasmid_names)
+            all_chassis_set.add(chassis_name)
+
+        return transformations, list(sorted(all_plasmids_set)), list(sorted(all_chassis_set))
 
     def _merge_params(self, transformation_data: Optional[Dict], advanced_params: Optional[Dict], kwargs_params: Dict) -> Dict:
         """
@@ -146,9 +254,7 @@ class Transformation():
         # Includes both Transformation and HeatShockTransformation parameters
         valid_params = {
             # Transformation base parameters
-            'list_of_dna': None,
             'volume_dna': 20,
-            'competent_cells': None,
             'replicates': 2,
             'thermocycler_starting_well': 0,
             'thermocycler_labware': 'nest_96_wellplate_100ul_pcr_full_skirt',
@@ -183,11 +289,6 @@ class Transformation():
 
         # Start with defaults
         merged = valid_params.copy()
-
-        # Apply transformation_data (if provided)
-        if transformation_data is not None:
-            self._validate_param_structure(transformation_data, valid_params, 'transformation_data')
-            merged.update(transformation_data)
 
         # Apply advanced_params (if provided)
         if advanced_params is not None:
@@ -224,10 +325,53 @@ class Transformation():
 
 class HeatShockTransformation(Transformation):
     '''
-       Creates a protocol for automated transformation.
+    Heat shock transformation protocol for the Opentrons OT-2.
+
+    Automates the full heat shock transformation workflow: loading DNA and competent
+    cells into a thermocycler plate, running the heat shock cycle, adding recovery
+    media, and exporting a plating map for the next protocol step.
+
+    Inherits all base parameters from Transformation. The attributes below are
+    specific to the heat shock transformation protocol.
+
+    Attributes
+    ----------
+    transfer_volume_dna : float
+        Volume of DNA to transfer into each thermocycler well, in microliters.
+        By default, 2 microliters. Note: this is the volume actually pipetted per
+        reaction, distinct from volume_dna (the volume loaded into the source well).
+    transfer_volume_competent_cell : float
+        Volume of competent cells to transfer into each thermocycler well, in
+        microliters. By default, 20 microliters.
+    tube_volume_competent_cell : float
+        Total usable volume of competent cells per tube, in microliters. Used to
+        calculate how many reactions each tube can supply before switching to the
+        next tube. By default, 100 microliters.
+    transfer_volume_recovery_media : float
+        Volume of recovery media to add to each well after heat shock, in
+        microliters. By default, 60 microliters.
+    tube_volume_recovery_media : float
+        Total usable volume of recovery media per tube, in microliters. Used to
+        calculate how many wells each tube can supply. By default, 1200 microliters.
+    cold_incubation1 : dict
+        First cold incubation step (on ice before heat shock). A dict with keys
+        'temperature' (°C) and 'hold_time_minutes'.
+        By default, {'temperature': 4, 'hold_time_minutes': 30}.
+    heat_shock : dict
+        Heat shock step. A dict with keys 'temperature' (°C) and 'hold_time_minutes'.
+        By default, {'temperature': 42, 'hold_time_minutes': 1}.
+    cold_incubation2 : dict
+        Second cold incubation immediately after heat shock. A dict with keys
+        'temperature' (°C) and 'hold_time_minutes'.
+        By default, {'temperature': 4, 'hold_time_minutes': 2}.
+    recovery_incubation : dict
+        Recovery incubation after recovery media addition. A dict with keys
+        'temperature' (°C) and 'hold_time_minutes'.
+        By default, {'temperature': 37, 'hold_time_minutes': 60}.
     '''
     def __init__(self,
-                transformation_data: Optional[Dict] = None,
+                transformation_data: Optional[List] = None,
+                plasmid_locations: Optional[Dict] = None,
                 json_params: Optional[Dict] = None,
                 transfer_volume_dna:float = 2,
                 transfer_volume_competent_cell:float = 20,
@@ -241,6 +385,7 @@ class HeatShockTransformation(Transformation):
                 *args, **kwargs):
         super().__init__(
             transformation_data=transformation_data,
+            plasmid_locations=plasmid_locations,
             json_params=json_params,
             transfer_volume_dna=transfer_volume_dna,
             transfer_volume_competent_cell=transfer_volume_competent_cell,
@@ -285,6 +430,8 @@ class HeatShockTransformation(Transformation):
             self.recovery_incubation = recovery_incubation
         self.dict_of_parts_in_temp_mod_position = {}
         self.dict_of_parts_in_thermocycler = {}
+        self.dict_of_parts_in_dna_plate = {}
+        self.plasmid_name_to_wells = {}  # plasmid name -> [well_obj, ...], populated during loading
 
     def _export_plating_input(self, protocol):
         """
@@ -359,21 +506,15 @@ class HeatShockTransformation(Transformation):
         tiprack_p200 = protocol.load_labware(self.tiprack_p200_labware, self.tiprack_p200_position)
         # Load the pipette
         pipette_p20 = protocol.load_instrument(self.pipette_p20, self.pipette_p20_position, tip_racks=[tiprack_p20])
-        pipette_p300 = protocol.load_instrument(self.pipette_p300, self.pipette_p300_position,
-                                                tip_racks=[tiprack_p200])
+        pipette_p300 = protocol.load_instrument(self.pipette_p300, self.pipette_p300_position, tip_racks=[tiprack_p200])
         #Validate protocol
         self._validate_protocol(protocol, alumblock)
 
-        #Load Reagents
+        #Load Reagents (also populates self.plasmid_name_to_wells)
         if self.use_dna_96plate:
-            DNA_wells = self._load_dna_list(protocol, dna_plate, self.volume_dna, self.list_of_dna, initial_well=self.initial_dna_well)
-            competent_cell_wells = self._load_reagents(protocol, alumblock, self.tube_volume_competent_cell, f"Competent Cell {self.competent_cells}", self.competent_cell_tubes_needed)
-            media_wells = self._load_reagents(protocol, alumblock, self.tube_volume_recovery_media, "Media", self.media_tubes_needed, initial_well=len(competent_cell_wells))
-
+            competent_cell_wells_by_chassis, media_wells = self._load_reagents_96plate(protocol, dna_plate, alumblock)
         else:
-            DNA_wells = self._load_dna_list(protocol, alumblock, self.volume_dna, self.list_of_dna)
-            competent_cell_wells = self._load_reagents(protocol, alumblock, self.tube_volume_competent_cell, f"Competent Cell {self.competent_cells}", self.competent_cell_tubes_needed, initial_well=len(DNA_wells))
-            media_wells = self._load_reagents(protocol, alumblock, self.tube_volume_recovery_media, "Media", self.media_tubes_needed, initial_well=len(DNA_wells)+len(competent_cell_wells))
+            competent_cell_wells_by_chassis, media_wells = self._load_reagents_temp_module(protocol, alumblock)
 
         #Set Temperature module and Thermocycler module to 4
         thermocycler_module.open_lid()
@@ -383,14 +524,14 @@ class HeatShockTransformation(Transformation):
 
         #Load competent cells into the thermocycler
         pipette = pipette_p300
-        self._transfer_competent_cells(protocol, pipette, pcr_plate, competent_cell_wells, self.transfer_volume_competent_cell, self.thermocycler_starting_well)
+        self._transfer_competent_cells(protocol, pipette, pcr_plate, competent_cell_wells_by_chassis, self.transfer_volume_competent_cell, self.thermocycler_starting_well)
 
         #Load DNA into the thermocycler
         if self.transfer_volume_dna > 20:
             pipette = pipette_p300
         else:
             pipette = pipette_p20
-        self._transfer_DNA(protocol, pipette, pcr_plate, DNA_wells, self.transfer_volume_dna, self.thermocycler_starting_well)
+        self._transfer_DNA(protocol, pipette, pcr_plate, self.transfer_volume_dna, self.thermocycler_starting_well)
 
         # Cold Incubation
         thermocycler_module.close_lid()
@@ -425,92 +566,223 @@ class HeatShockTransformation(Transformation):
         # output
         print('Strain and media tube in temp_mod')
         print(self.dict_of_parts_in_temp_mod_position)
+        if self.use_dna_96plate:
+            print('DNA constructs in DNA plate (slot 2)')
+            print(self.dict_of_parts_in_dna_plate)
         print('Genetically modified organisms in thermocycler')
         print(self.dict_of_parts_in_thermocycler)
 
     def _validate_protocol(self, protocol, labware):
+        """
+        Validate protocol requirements and compute all derived counts used throughout run().
+        Sets: self.location_replicates, self.total_transformations,
+              self.transformations_per_cell_tube, self.competent_cell_tubes_by_chassis,
+              self.reactions_by_chassis, self.transformations_per_media_tube,
+              self.media_tubes_needed.
+        Raises ValueError if reagents exceed available alumblock wells.
+        """
         #Number of available wells to load into
         module_wells = len(labware.wells())
-        #Number of dna constructs to be used
-        total_constructs = len(self.list_of_dna)
-        #Number of tubes with competent cells to be used
-        self.total_transformations = total_constructs*self.replicates
-        self.transformations_per_cell_tube = self.tube_volume_competent_cell//self.transfer_volume_competent_cell
-        self.competent_cell_tubes_needed = (self.total_transformations + self.transformations_per_cell_tube - 1) // self.transformations_per_cell_tube
+
+        #Number of strains to transform
+        total_strains = len(self.transformations)
+
+        #Number of total plasmid wells needed (one well per unique plasmid)
+        total_plasmid_wells = len(self.all_plasmids)
+
+        # Number of location replicates per strain (assembly replicates of the same plasmid in plate,
+        # always 1 for temp module since plasmids are in a single sequential well)
+        if self.plasmid_locations is not None:
+            self.location_replicates = len(next(iter(self.plasmid_locations.values())))
+        else:
+            self.location_replicates = 1
+
+        #Total transformation reactions
+        self.total_transformations = total_strains * self.location_replicates * self.replicates
+
+        #Calculate competent cell tubes needed per chassis type
+        self.transformations_per_cell_tube = self.tube_volume_competent_cell // self.transfer_volume_competent_cell
+        self.competent_cell_tubes_by_chassis = {}
+        self.reactions_by_chassis = {}
+        total_competent_cell_tubes = 0
+
+        for chassis in self.all_chassis:
+            # Count how many transformations use this chassis
+            transformations_for_chassis = sum(1 for t in self.transformations if t['chassis'] == chassis)
+            reactions_for_chassis = transformations_for_chassis * self.location_replicates * self.replicates
+            self.reactions_by_chassis[chassis] = reactions_for_chassis
+            tubes_needed = (reactions_for_chassis + self.transformations_per_cell_tube - 1) // self.transformations_per_cell_tube
+            self.competent_cell_tubes_by_chassis[chassis] = tubes_needed
+            total_competent_cell_tubes += tubes_needed
+
         #Number of tubes with media to be used
-        self.transformations_per_media_tube = self.tube_volume_recovery_media//self.transfer_volume_recovery_media
+        self.transformations_per_media_tube = self.tube_volume_recovery_media // self.transfer_volume_recovery_media
         self.media_tubes_needed = (self.total_transformations + self.transformations_per_media_tube - 1) // self.transformations_per_media_tube
+
+        #Validate wells
         if self.use_dna_96plate:
-            if self.competent_cell_tubes_needed + self.media_tubes_needed > module_wells:
-                raise ValueError(f'The number of reagents is more that {module_wells}.'
-                                 f'There are {self.competent_cell_tubes_needed} tubes with competent cells.'
+            # DNA is on a separate plate, only cells and media on the temp module
+            if total_competent_cell_tubes + self.media_tubes_needed > module_wells:
+                raise ValueError(f'The number of reagents is more than {module_wells}.'
+                                 f'There are {total_competent_cell_tubes} tubes with competent cells ({self.competent_cell_tubes_by_chassis}).'
                                  f'{self.media_tubes_needed} tubes with media.'
                                  f'Please modify the protocol and try again.')
         else:
-            if total_constructs + self.competent_cell_tubes_needed + self.media_tubes_needed > module_wells:
+            # DNA, cells, and media all on the temp module
+            if total_plasmid_wells + total_competent_cell_tubes + self.media_tubes_needed > module_wells:
                 raise ValueError(f'The number of reagents is more than {module_wells}.'
-                                 f'There are {total_constructs} DNA constructs.'
-                                 f'{self.competent_cell_tubes_needed} tubes with competent cells.'
+                                 f'There are {total_plasmid_wells} plasmid wells.'
+                                 f'{total_competent_cell_tubes} tubes with competent cells ({self.competent_cell_tubes_by_chassis}).'
                                  f'{self.media_tubes_needed} tubes with media.'
                                  f'Please modify the protocol and try again.')
 
 
-    def _load_dna_list(self, protocol, labware, volume, dna_list, initial_well=0, description=None, color_index = None):
+    def _load_reagents_96plate(self, protocol, dna_plate, alumblock):
         """
-        Load individual DNA constructs into wells, one construct per well.
+        Load all reagents for the 96-well plate workflow (plasmid_locations provided).
+        DNA constructs are loaded from the assembly output plate at their fixed positions —
+        populates self.plasmid_name_to_wells. Competent cells and media are loaded
+        sequentially onto the alumblock starting at well 0.
 
         Parameters:
         - protocol: Protocol context
-        - labware: Labware object (temperature module or DNA plate)
-        - volume: Volume to load in µL
-        - construct_list: List of construct names (e.g., ['GVD0011', 'GVD0013'])
-        - initial_well: Starting well index
-        - color_index: Starting color index (auto-increments if None)
+        - dna_plate: 96-well plate labware object (slot 2)
+        - alumblock: Temperature module labware object
 
         Returns:
-        - List of well objects
+        - competent_cell_wells_by_chassis: dict mapping chassis name to list of well objects
+        - media_wells: list of well objects
         """
-        wells = []
-        current_color = color_index if color_index is not None else 0
-        for i, construct in enumerate(dna_list):
-            #Get the well
-            well = labware.wells()[initial_well+i]
-            wells.append(well)
+        # Load DNA from dna_plate at actual well positions from plasmid_locations
+        # Populates self.plasmid_name_to_wells
+        self._load_dna_into_dna_plate(protocol, dna_plate)
 
-            #Covert tuple to string if needed
-            if isinstance(construct, tuple):
-                construct_name = '_'.join(construct)
-            else:
-                construct_name = construct
-            #Define and load "liquid"
-            liquid = protocol.define_liquid(
-                name = construct_name,
-                description= description if description is not None else f"{construct} DNA construct",
-                display_color= colors[current_color%len(colors)]
-            )
-            well.load_liquid(liquid, volume=volume)
+        # Load competent cells for each chassis onto alumblock
+        competent_cell_wells_by_chassis = {}
+        current_well = 0
+        for chassis in self.all_chassis:
+            tubes_needed = self.competent_cell_tubes_by_chassis[chassis]
+            wells = self._load_reagents(protocol, alumblock, self.tube_volume_competent_cell,
+                                        f"Competent Cell {chassis}", tubes_needed, initial_well=current_well)
+            competent_cell_wells_by_chassis[chassis] = wells
+            current_well += tubes_needed
 
-            #Track in dictionary
-            if not self.use_dna_96plate:
-                self.dict_of_parts_in_temp_mod_position[construct_name] = well.well_name
+        # Load media onto alumblock
+        media_wells = self._load_reagents(protocol, alumblock, self.tube_volume_recovery_media,
+                                          "Media", self.media_tubes_needed, initial_well=current_well)
+
+        return competent_cell_wells_by_chassis, media_wells
+
+    def _load_dna_into_dna_plate(self, protocol, dna_plate):
+        """
+        Load DNA constructs into their fixed positions on the 96-well DNA plate.
+        Positions are determined by plasmid_locations (from assembly output or MoClo kit layout).
+        Each construct may occupy multiple wells (assembly replicates).
+        Populates self.plasmid_name_to_wells: {construct_name: [well_obj, ...]}
+
+        Parameters:
+        - protocol: Protocol context
+        - dna_plate: 96-well plate labware object on slot 2
+        """
+        current_color = 0
+        name_to_uri = {self._extract_name_from_uri(uri): uri for uri in self.plasmid_locations}
+
+        for construct_name in self.all_plasmids:
+            uri = name_to_uri[construct_name]
+            well_names = self.plasmid_locations[uri]
+            well_objects = []
+
+            for i, well_name in enumerate(well_names):
+                well = dna_plate.wells_by_name()[well_name]
+                well_objects.append(well)
+                if i == 0:
+                    liquid = protocol.define_liquid(
+                        name=construct_name,
+                        description=f"{construct_name} DNA construct",
+                        display_color=colors[current_color % len(colors)]
+                    )
+                well.load_liquid(liquid, volume=self.volume_dna)
+
+            self.plasmid_name_to_wells[construct_name] = well_objects
+            self.dict_of_parts_in_dna_plate[construct_name] = well_names
             current_color += 1
-        return wells
+
+    def _load_reagents_temp_module(self, protocol, alumblock):
+        """
+        Load all reagents for the temp module workflow (no plasmid_locations).
+        DNA constructs are loaded sequentially starting at initial_dna_well —
+        populates self.plasmid_name_to_wells. Competent cells and media follow
+        sequentially on the same alumblock.
+
+        Parameters:
+        - protocol: Protocol context
+        - alumblock: Temperature module labware object
+
+        Returns:
+        - competent_cell_wells_by_chassis: dict mapping chassis name to list of well objects
+        - media_wells: list of well objects
+        """
+        # Load DNA sequentially onto alumblock starting at initial_dna_well
+        # Populates self.plasmid_name_to_wells
+        self._load_dna_into_temp_module(protocol, alumblock)
+
+        # Load competent cells for each chassis, starting after the DNA wells
+        competent_cell_wells_by_chassis = {}
+        current_well = self.initial_dna_well + len(self.all_plasmids)
+        for chassis in self.all_chassis:
+            tubes_needed = self.competent_cell_tubes_by_chassis[chassis]
+            wells = self._load_reagents(protocol, alumblock, self.tube_volume_competent_cell,
+                                        f"Competent Cell {chassis}", tubes_needed, initial_well=current_well)
+            competent_cell_wells_by_chassis[chassis] = wells
+            current_well += tubes_needed
+
+        # Load media onto alumblock after competent cells
+        media_wells = self._load_reagents(protocol, alumblock, self.tube_volume_recovery_media,
+                                          "Media", self.media_tubes_needed, initial_well=current_well)
+
+        return competent_cell_wells_by_chassis, media_wells
+
+    def _load_dna_into_temp_module(self, protocol, alumblock):
+        """
+        Load DNA constructs sequentially into the temperature module alumblock.
+        Positions are assigned sequentially starting at initial_dna_well.
+        Populates self.plasmid_name_to_wells: {construct_name: [well_obj]} (single-element list).
+
+        Parameters:
+        - protocol: Protocol context
+        - alumblock: Temperature module labware object
+        """
+        current_color = 0
+
+        for i, construct_name in enumerate(self.all_plasmids):
+            well = alumblock.wells()[self.initial_dna_well + i]
+            liquid = protocol.define_liquid(
+                name=construct_name,
+                description=f"{construct_name} DNA construct",
+                display_color=colors[current_color % len(colors)]
+            )
+            well.load_liquid(liquid, volume=self.volume_dna)
+            self.plasmid_name_to_wells[construct_name] = [well]
+            self.dict_of_parts_in_temp_mod_position[construct_name] = well.well_name
+            current_color += 1
 
     def _load_reagents(self, protocol, labware, volume, reagent_name, tube_count, initial_well=0, color_index=None):
         """
-        Load multiple tubes of the same reagent type.
+        Load multiple tubes of the same reagent type onto a labware object.
+        Tubes are named {reagent_name}_1, {reagent_name}_2, etc. and tracked
+        in self.dict_of_parts_in_temp_mod_position.
 
         Parameters:
         - protocol: Protocol context
-        - labware: Labware object (temperature module)
-        - volume: Volume to load in µL
-        - reagent_base_name: Base name for reagent (e.g., "Competent_Cell", "Media")
+        - labware: Labware object to load reagents onto
+        - volume: Volume per tube in µL
+        - reagent_name: Base name for the reagent (e.g., "Competent Cell DH5alpha", "Media")
         - tube_count: Number of tubes to load
-        - initial_well: Starting well index
-        - color_index: Starting color index (auto-increments if None)
+        - initial_well: Starting well index on the labware
+        - color_index: Starting color index for Opentrons UI (cycles through colors list)
 
         Returns:
-        - List of well objects
+        - List of well objects in order
         """
         wells = []
         current_color = color_index if color_index is not None else 0
@@ -529,95 +801,118 @@ class HeatShockTransformation(Transformation):
             current_color += 1
         return wells
 
-    def _transfer_competent_cells(self, protocol, pipette, pcr_plate, competent_cell_wells,
+    def _transfer_competent_cells(self, protocol, pipette, pcr_plate, competent_cell_wells_by_chassis,
                                   transfer_volume_competent_cell, thermocycler_starting_well):
         """
-        Transfer competent cells to thermocycler wells using distribute method.
+        Transfer competent cells into thermocycler wells, one well per reaction.
+        Iterates self.transformations as ground truth. For each strain, fills
+        location_replicates * replicates wells with the appropriate chassis cells.
+        Tube selection is per-chassis (chassis_reaction_count) so multiple chassis
+        types each consume only their own tubes independently.
 
         Parameters:
         - protocol: Protocol context
-        - pipette: Pipette instrument
-        - pcr_plate: Thermocycler plate
-        - competent_cell_wells: List of wells containing competent cells
-        - transfer_volume_competent_cell: Volume to transfer per well
-        - thermocycler_starting_well: Starting well index in thermocycler
+        - pipette: Pipette instrument (p300)
+        - pcr_plate: Thermocycler plate labware
+        - competent_cell_wells_by_chassis: Dict mapping chassis name to list of well objects
+        - transfer_volume_competent_cell: Volume to transfer per well in µL
+        - thermocycler_starting_well: Starting well index in thermocycler plate
         """
         well_index = thermocycler_starting_well
+        chassis_reaction_count = {chassis: 0 for chassis in self.all_chassis}
 
-        for tube_index, source_well in enumerate(competent_cell_wells):
-            #Calculate how many wells this cell tube will fill
-            remaining_transformations = self.total_transformations - (tube_index * self.transformations_per_cell_tube)
-            wells_to_fill = min(self.transformations_per_cell_tube, remaining_transformations)
+        for transformation in self.transformations:
+            chassis = transformation['chassis']
+            cell_wells = competent_cell_wells_by_chassis[chassis]
 
-            #Destination wells
-            dest_wells = pcr_plate.wells()[well_index:well_index+wells_to_fill]
+            for replicate in range(self.location_replicates * self.replicates):
+                dest_well = pcr_plate.wells()[well_index]
 
-            #Distribute
-            pipette.distribute(
-                volume=transfer_volume_competent_cell,
-                source=source_well,
-                dest=dest_wells,
-                mix_before=(3,50),
-                disposal_volume=0,
-                new_tip='once'
-            )
+                # Select tube based on per-chassis reaction count
+                tube_index = chassis_reaction_count[chassis] // self.transformations_per_cell_tube
+                source_well = cell_wells[tube_index]
 
-            #Thermocycler Dictionary
-            name = f"Competent_Cell_{self.competent_cells}_{tube_index+1}"
-            for well in dest_wells:
-                if well.well_name not in self.dict_of_parts_in_thermocycler:
-                    self.dict_of_parts_in_thermocycler[well.well_name] = []
-                self.dict_of_parts_in_thermocycler[well.well_name].append(name)
-
-            well_index += wells_to_fill
-
-    def _transfer_DNA(self, protocol, pipette, pcr_plate, DNA_wells, transfer_volume_dna, thermocycler_starting_well):
-        """
-        Transfer DNA constructs to thermocycler wells with replicates grouped together.
-
-        Parameters:
-        - protocol: Protocol context
-        - pipette: Pipette instrument
-        - pcr_plate: Thermocycler plate
-        - DNA_wells: List of wells containing DNA constructs
-        - transfer_volume_dna: Volume to transfer per well
-        - thermocycler_starting_well: Starting well index in thermocycler
-        """
-        for construct_index, (construct_name, source_well) in enumerate(zip(self.list_of_dna, DNA_wells)):
-            construct_well = construct_index * self.replicates + thermocycler_starting_well
-
-            for replicate in range(self.replicates):
-                dest_well = pcr_plate.wells()[construct_well+replicate]
-                #Transfer liquid
                 self.liquid_transfer(
                     protocol=protocol,
                     pipette=pipette,
-                    volume=transfer_volume_dna,
+                    volume=transfer_volume_competent_cell,
                     source=source_well,
                     dest=dest_well,
                     asp_rate=self.aspiration_rate,
                     disp_rate=self.dispense_rate,
-                    mix_before=transfer_volume_dna,
-                    touch_tip=True
+                    mix_before=20,
+                    touch_tip=False
                 )
 
-                #Track in dictionary
+                name = f"Competent_Cell_{chassis}"
                 if dest_well.well_name not in self.dict_of_parts_in_thermocycler:
-                    self.dict_of_parts_in_thermocycler[dest_well.well_name] = []
-                self.dict_of_parts_in_thermocycler[dest_well.well_name].append(construct_name)
+                    self.dict_of_parts_in_thermocycler[dest_well.well_name] = [transformation['strain']]
+                self.dict_of_parts_in_thermocycler[dest_well.well_name].append(name)
 
-    def _transfer_liquid_broth(self, protocol, pipette, pcr_plate, media_wells, transfer_volume_recovery_media,
-                               thermocycler_starting_well):
+                chassis_reaction_count[chassis] += 1
+                well_index += 1
+
+    def _transfer_DNA(self, protocol, pipette, pcr_plate, transfer_volume_dna, thermocycler_starting_well):
         """
-        Transfer recovery media to thermocycler wells using distribute method.
+        Transfer DNA plasmids to thermocycler wells. Multiple plasmids per strain go to the same well.
+        Uses self.plasmid_name_to_wells (populated during loading) for all source well lookups —
+        no positional indexing, fully name-driven from self.transformations.
+
+        For the temp module path: each plasmid has one well → location_replicates = 1
+        For the dna plate path: each plasmid has N wells (assembly replicates) → location_replicates = N
 
         Parameters:
         - protocol: Protocol context
         - pipette: Pipette instrument
         - pcr_plate: Thermocycler plate
-        - media_wells: List of wells containing recovery media
-        - transfer_volume_recovery_media: Volume to transfer per well
+        - transfer_volume_dna: Volume to transfer per plasmid
         - thermocycler_starting_well: Starting well index in thermocycler
+        """
+        well_index = thermocycler_starting_well
+
+        for transformation in self.transformations:
+            plasmids = transformation['plasmids']
+
+            for loc_idx in range(self.location_replicates):
+                for replicate in range(self.replicates):
+                    dest_well = pcr_plate.wells()[well_index]
+
+                    for plasmid_name in plasmids:
+                        source_well = self.plasmid_name_to_wells[plasmid_name][loc_idx]
+
+                        self.liquid_transfer(
+                            protocol=protocol,
+                            pipette=pipette,
+                            volume=transfer_volume_dna,
+                            source=source_well,
+                            dest=dest_well,
+                            asp_rate=self.aspiration_rate,
+                            disp_rate=self.dispense_rate,
+                            mix_before=transfer_volume_dna,
+                            touch_tip=True
+                        )
+
+                        if dest_well.well_name not in self.dict_of_parts_in_thermocycler:
+                            self.dict_of_parts_in_thermocycler[dest_well.well_name] = []
+                        self.dict_of_parts_in_thermocycler[dest_well.well_name].append(plasmid_name)
+
+                    well_index += 1
+
+    def _transfer_liquid_broth(self, protocol, pipette, pcr_plate, media_wells, transfer_volume_recovery_media,
+                               thermocycler_starting_well):
+        """
+        Distribute recovery media into all thermocycler wells using the pipette distribute method.
+        Each media tube fills up to transformations_per_media_tube wells before moving to the next.
+        Uses .top(2) on dest wells to avoid contamination from the pipette tip.
+        Covers self.total_transformations wells in total.
+
+        Parameters:
+        - protocol: Protocol context
+        - pipette: Pipette instrument (p300)
+        - pcr_plate: Thermocycler plate labware
+        - media_wells: List of well objects containing recovery media
+        - transfer_volume_recovery_media: Volume to distribute per well in µL
+        - thermocycler_starting_well: Starting well index in thermocycler plate
         """
         well_index = thermocycler_starting_well
 

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -673,6 +673,11 @@ class HeatShockTransformation(Transformation):
                     f"plasmid_locations has inconsistent replicate counts across plasmids — "
                     f"all plasmids must have the same number of wells. Found: {detail}"
                 )
+            if unique_counts == {0}:
+                raise ValueError(
+                    "plasmid_locations contains empty well lists for all referenced plasmids. "
+                    "Each plasmid must have at least one destination well."
+                )
             self.location_replicates = unique_counts.pop() if unique_counts else 1
         else:
             self.location_replicates = 1

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -1,3 +1,4 @@
+from itertools import groupby
 from opentrons import protocol_api
 from typing import List, Dict, Optional
 from pudu.utils import colors
@@ -804,11 +805,15 @@ class HeatShockTransformation(Transformation):
     def _transfer_competent_cells(self, protocol, pipette, pcr_plate, competent_cell_wells_by_chassis,
                                   transfer_volume_competent_cell, thermocycler_starting_well):
         """
-        Transfer competent cells into thermocycler wells, one well per reaction.
+        Transfer competent cells into thermocycler wells.
         Iterates self.transformations as ground truth. For each strain, fills
         location_replicates * replicates wells with the appropriate chassis cells.
         Tube selection is per-chassis (chassis_reaction_count) so multiple chassis
         types each consume only their own tubes independently.
+
+        Tips are reused within each consecutive source tube block (one pickup per tube)
+        by batching destinations with distribute(). A new tip is picked up whenever the
+        source tube changes, preventing cross-chassis contamination.
 
         Parameters:
         - protocol: Protocol context
@@ -818,6 +823,8 @@ class HeatShockTransformation(Transformation):
         - transfer_volume_competent_cell: Volume to transfer per well in µL
         - thermocycler_starting_well: Starting well index in thermocycler plate
         """
+        # Pre-compute all transfers as (source_well, dest_well, chassis, strain)
+        transfers = []
         well_index = thermocycler_starting_well
         chassis_reaction_count = {chassis: 0 for chassis in self.all_chassis}
 
@@ -825,32 +832,34 @@ class HeatShockTransformation(Transformation):
             chassis = transformation['chassis']
             cell_wells = competent_cell_wells_by_chassis[chassis]
 
-            for replicate in range(self.location_replicates * self.replicates):
+            for _ in range(self.location_replicates * self.replicates):
                 dest_well = pcr_plate.wells()[well_index]
-
-                # Select tube based on per-chassis reaction count
                 tube_index = chassis_reaction_count[chassis] // self.transformations_per_cell_tube
                 source_well = cell_wells[tube_index]
-
-                self.liquid_transfer(
-                    protocol=protocol,
-                    pipette=pipette,
-                    volume=transfer_volume_competent_cell,
-                    source=source_well,
-                    dest=dest_well,
-                    asp_rate=self.aspiration_rate,
-                    disp_rate=self.dispense_rate,
-                    mix_before=20,
-                    touch_tip=False
-                )
-
-                name = f"Competent_Cell_{chassis}"
-                if dest_well.well_name not in self.dict_of_parts_in_thermocycler:
-                    self.dict_of_parts_in_thermocycler[dest_well.well_name] = [transformation['strain']]
-                self.dict_of_parts_in_thermocycler[dest_well.well_name].append(name)
+                transfers.append((source_well, dest_well, chassis, transformation['strain']))
 
                 chassis_reaction_count[chassis] += 1
                 well_index += 1
+
+        # Distribute per consecutive source tube — one tip pickup per tube.
+        # dict_of_parts_in_thermocycler is updated after each distribute() call
+        # so it reflects only wells that have actually been filled.
+        for source_well, group in groupby(transfers, key=lambda t: t[0]):
+            group_list = list(group)
+            dest_wells = [t[1] for t in group_list]
+            pipette.distribute(
+                volume=transfer_volume_competent_cell,
+                source=source_well,
+                dest=dest_wells,
+                mix_before=(3, 50),
+                disposal_volume=0,
+                new_tip='once'
+            )
+            for _, dest_well, chassis, strain in group_list:
+                name = f"Competent_Cell_{chassis}"
+                if dest_well.well_name not in self.dict_of_parts_in_thermocycler:
+                    self.dict_of_parts_in_thermocycler[dest_well.well_name] = [strain]
+                self.dict_of_parts_in_thermocycler[dest_well.well_name].append(name)
 
     def _transfer_DNA(self, protocol, pipette, pcr_plate, transfer_volume_dna, thermocycler_starting_well):
         """

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -1,0 +1,261 @@
+"""
+Unit tests for HeatShockTransformation validation logic.
+
+These tests cover __init__ parsing, _validate_protocol edge cases, and
+the specific issues identified in code review:
+  - P1: tip reuse for competent cell distribution (verified via simulation)
+  - P2: inconsistent plasmid replicate counts in plasmid_locations
+
+Tests are split into:
+  - TestTransformationDataParsing  : __init__ / _parse_transformation_data
+  - TestValidateProtocol           : _validate_protocol edge cases
+"""
+
+import unittest
+from unittest.mock import MagicMock
+from pudu.transformation import HeatShockTransformation
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+def make_transformation(transformation_data, plasmid_locations=None, **kwargs):
+    """Convenience wrapper — instantiate HeatShockTransformation with minimal args."""
+    return HeatShockTransformation(
+        transformation_data=transformation_data,
+        plasmid_locations=plasmid_locations,
+        **kwargs
+    )
+
+
+class MockLabware:
+    """Minimal stand-in for an alumblock labware in _validate_protocol."""
+    def __init__(self, num_wells=24):
+        self._wells = [MagicMock() for _ in range(num_wells)]
+
+    def wells(self):
+        return self._wells
+
+
+# Reusable transformation data blocks
+
+SINGLE_DH5ALPHA = [
+    {
+        'Strain':  'https://SBOL2Build.org/strain_1/1',
+        'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+        'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+    }
+]
+
+TWO_STRAINS_TWO_PLASMIDS = [
+    {
+        'Strain':  'https://SBOL2Build.org/strain_1/1',
+        'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+        'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+    },
+    {
+        'Strain':  'https://SBOL2Build.org/strain_2/1',
+        'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+        'Plasmids': ['https://SBOL2Build.org/plasmid_2/1']
+    }
+]
+
+MULTI_CHASSIS = [
+    {
+        'Strain':  'https://SBOL2Build.org/strain_1/1',
+        'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+        'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+    },
+    {
+        'Strain':  'https://SBOL2Build.org/strain_2/1',
+        'Chassis': 'https://sbolcanvas.org/BL21/1',
+        'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+    }
+]
+
+CONSISTENT_PLASMID_LOCATIONS = {
+    'https://SBOL2Build.org/plasmid_1/1': ['A1', 'B1'],
+    'https://SBOL2Build.org/plasmid_2/1': ['C1', 'D1']
+}
+
+INCONSISTENT_PLASMID_LOCATIONS = {
+    'https://SBOL2Build.org/plasmid_1/1': ['A1', 'B1'],   # 2 replicates
+    'https://SBOL2Build.org/plasmid_2/1': ['C1']           # 1 replicate
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Transformation data parsing (__init__ / _parse_transformation_data)
+# ---------------------------------------------------------------------------
+
+class TestTransformationDataParsing(unittest.TestCase):
+
+    def test_none_transformation_data_raises(self):
+        """transformation_data=None must raise immediately."""
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(transformation_data=None)
+        self.assertIn('Must provide', str(ctx.exception))
+
+    def test_transformation_data_not_list_raises(self):
+        """A dict passed as transformation_data must raise (old API format)."""
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(transformation_data={
+                'list_of_dna': ['pA', 'pB'],
+                'competent_cells': 'DH5alpha'
+            })
+        self.assertIn('must be a list', str(ctx.exception))
+
+    def test_missing_strain_field_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(transformation_data=[{
+                'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+            }])
+        self.assertIn("missing 'Strain'", str(ctx.exception))
+
+    def test_missing_chassis_field_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(transformation_data=[{
+                'Strain':  'https://SBOL2Build.org/strain_1/1',
+                'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+            }])
+        self.assertIn("missing 'Chassis'", str(ctx.exception))
+
+    def test_missing_plasmids_field_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(transformation_data=[{
+                'Strain':  'https://SBOL2Build.org/strain_1/1',
+                'Chassis': 'https://sbolcanvas.org/DH5alpha/1'
+            }])
+        self.assertIn("missing 'Plasmids'", str(ctx.exception))
+
+    def test_empty_plasmids_list_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(transformation_data=[{
+                'Strain':  'https://SBOL2Build.org/strain_1/1',
+                'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                'Plasmids': []
+            }])
+        self.assertIn('cannot be empty', str(ctx.exception))
+
+    def test_use_dna_96plate_without_plasmid_locations_raises(self):
+        """use_dna_96plate=True requires plasmid_locations."""
+        with self.assertRaises(ValueError) as ctx:
+            HeatShockTransformation(
+                transformation_data=SINGLE_DH5ALPHA,
+                use_dna_96plate=True
+            )
+        self.assertIn('plasmid_locations must be provided', str(ctx.exception))
+
+    def test_valid_single_chassis_parses(self):
+        t = make_transformation(SINGLE_DH5ALPHA)
+        self.assertEqual(len(t.transformations), 1)
+        self.assertEqual(t.all_chassis, ['DH5alpha'])
+        self.assertEqual(t.all_plasmids, ['plasmid_1'])
+
+    def test_valid_multi_chassis_parses(self):
+        t = make_transformation(MULTI_CHASSIS)
+        self.assertEqual(len(t.transformations), 2)
+        self.assertIn('DH5alpha', t.all_chassis)
+        self.assertIn('BL21', t.all_chassis)
+
+    def test_uri_and_plain_name_both_accepted(self):
+        """Plain names (non-URI) should work alongside full URIs."""
+        t = make_transformation([{
+            'Strain':  'strain_1',
+            'Chassis': 'DH5alpha',
+            'Plasmids': ['plasmid_1']
+        }])
+        self.assertEqual(t.all_chassis, ['DH5alpha'])
+        self.assertEqual(t.all_plasmids, ['plasmid_1'])
+
+
+# ---------------------------------------------------------------------------
+# 2. _validate_protocol edge cases
+# ---------------------------------------------------------------------------
+
+class TestValidateProtocol(unittest.TestCase):
+    """
+    Call _validate_protocol directly with a mock labware so we can test
+    validation logic without spinning up a full protocol context.
+    """
+
+    def _run_validate(self, transformation, num_wells=24):
+        transformation._validate_protocol(protocol=None, labware=MockLabware(num_wells))
+
+    # --- P2: inconsistent plasmid replicate counts ---
+
+    def test_inconsistent_plasmid_replicate_counts_raises(self):
+        """P2: plasmid_locations with uneven well-list lengths must raise."""
+        t = make_transformation(
+            TWO_STRAINS_TWO_PLASMIDS,
+            plasmid_locations=INCONSISTENT_PLASMID_LOCATIONS
+        )
+        with self.assertRaises(ValueError) as ctx:
+            self._run_validate(t)
+        self.assertIn('inconsistent replicate counts', str(ctx.exception))
+
+    def test_consistent_plasmid_replicate_counts_passes(self):
+        """Matching well-list lengths must not raise."""
+        t = make_transformation(
+            TWO_STRAINS_TWO_PLASMIDS,
+            plasmid_locations=CONSISTENT_PLASMID_LOCATIONS
+        )
+        # Should complete without error
+        self._run_validate(t)
+        self.assertEqual(t.location_replicates, 2)
+
+    def test_single_plasmid_location_passes(self):
+        """Single plasmid — trivially consistent."""
+        t = make_transformation(
+            SINGLE_DH5ALPHA,
+            plasmid_locations={'https://SBOL2Build.org/plasmid_1/1': ['A1', 'B1', 'C1']}
+        )
+        self._run_validate(t)
+        self.assertEqual(t.location_replicates, 3)
+
+    # --- Reagent capacity ---
+
+    def test_too_many_reagents_for_alumblock_raises(self):
+        """
+        20 unique plasmids + competent cell tubes + media tubes > 24 wells.
+        Uses temp module path (no plasmid_locations).
+        """
+        overflow_data = [
+            {
+                'Strain':  f'https://SBOL2Build.org/strain_{i}/1',
+                'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                'Plasmids': [f'https://SBOL2Build.org/plasmid_{i}/1']
+            }
+            for i in range(20)
+        ]
+        t = make_transformation(overflow_data)
+        with self.assertRaises(ValueError) as ctx:
+            self._run_validate(t, num_wells=24)
+        self.assertIn('more than', str(ctx.exception))
+
+    def test_reagents_exactly_at_capacity_passes(self):
+        """
+        Verify that a protocol fitting exactly within the alumblock does not raise.
+        1 plasmid + 1 chassis tube + 1 media tube = 3 wells — well within 24.
+        """
+        t = make_transformation(SINGLE_DH5ALPHA)
+        self._run_validate(t, num_wells=24)
+
+    def test_multi_chassis_reagent_count(self):
+        """
+        Multi-chassis: each chassis gets its own cell tube(s).
+        2 strains × 1 chassis each × 2 replicates = 4 reactions total,
+        1 tube per chassis (4 reactions < 5 per tube), 1 media tube.
+        Total: 2 plasmids + 2 cell tubes + 1 media = 5 wells — fits in 24.
+        """
+        t = make_transformation(MULTI_CHASSIS)
+        self._run_validate(t, num_wells=24)
+        self.assertEqual(len(t.competent_cell_tubes_by_chassis), 2)
+        self.assertEqual(t.competent_cell_tubes_by_chassis['DH5alpha'], 1)
+        self.assertEqual(t.competent_cell_tubes_by_chassis['BL21'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -233,8 +233,12 @@ class TestValidateProtocol(unittest.TestCase):
     validation logic without spinning up a full protocol context.
     """
 
-    def _run_validate(self, transformation, num_wells=24):
-        transformation._validate_protocol(protocol=None, labware=MockLabware(num_wells))
+    def _run_validate(self, transformation, num_wells=24, tube_rack_wells=24):
+        transformation._validate_protocol(
+            protocol=None,
+            labware=MockLabware(num_wells),
+            tube_rack=MockLabware(tube_rack_wells)
+        )
 
     # --- P2: inconsistent plasmid replicate counts ---
 
@@ -269,10 +273,10 @@ class TestValidateProtocol(unittest.TestCase):
 
     # --- Reagent capacity ---
 
-    def test_too_many_reagents_for_alumblock_raises(self):
+    def test_too_many_plasmids_for_alumblock_raises(self):
         """
-        20 unique plasmids + competent cell tubes + media tubes > 24 wells.
-        Uses temp module path (no plasmid_locations).
+        25 unique plasmids > 24 wells on the temperature module.
+        Cells and media are on the tube rack, so the alumblock check is plasmids-only.
         """
         overflow_data = [
             {
@@ -280,11 +284,21 @@ class TestValidateProtocol(unittest.TestCase):
                 'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
                 'Plasmids': [f'https://SBOL2Build.org/plasmid_{i}/1']
             }
-            for i in range(20)
+            for i in range(25)
         ]
         t = make_transformation(overflow_data)
         with self.assertRaises(ValueError) as ctx:
             self._run_validate(t, num_wells=24)
+        self.assertIn('more than', str(ctx.exception))
+
+    def test_too_many_tubes_for_tube_rack_raises(self):
+        """
+        Enough reactions to overflow a very small tube rack.
+        2 strains × 2 replicates = 4 reactions → 1 cell tube + 1 media tube = 2 > 1.
+        """
+        t = make_transformation(TWO_STRAINS_TWO_PLASMIDS)
+        with self.assertRaises(ValueError) as ctx:
+            self._run_validate(t, tube_rack_wells=1)
         self.assertIn('more than', str(ctx.exception))
 
     def test_reagents_exactly_at_capacity_passes(self):
@@ -298,10 +312,10 @@ class TestValidateProtocol(unittest.TestCase):
     def test_initial_dna_well_offset_included_in_capacity_check(self):
         """
         P2: initial_dna_well offset must be counted in the temp-module capacity check.
-        3 reagents (1 plasmid + 1 cell tube + 1 media tube) fit in 24 wells by raw count,
-        but starting at well 22 pushes the last reagent to well 24 — out of range.
+        Cells and media are now on the tube rack, so the alumblock holds only plasmids.
+        initial_dna_well=24 + 1 plasmid = 25 > 24 → out of range.
         """
-        t = make_transformation(SINGLE_DH5ALPHA, initial_dna_well=22)
+        t = make_transformation(SINGLE_DH5ALPHA, initial_dna_well=24)
         with self.assertRaises(ValueError) as ctx:
             self._run_validate(t, num_wells=24)
         self.assertIn('more than', str(ctx.exception))
@@ -309,7 +323,7 @@ class TestValidateProtocol(unittest.TestCase):
     def test_initial_dna_well_offset_within_capacity_passes(self):
         """A non-zero initial_dna_well that still fits within the block must not raise."""
         t = make_transformation(SINGLE_DH5ALPHA, initial_dna_well=5)
-        self._run_validate(t, num_wells=24)  # 5 + 1 + 1 + 1 = 8 <= 24
+        self._run_validate(t, num_wells=24)  # 5 + 1 plasmid = 6 <= 24
 
     def test_multi_chassis_reagent_count(self):
         """

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -9,6 +9,7 @@ the specific issues identified in code review:
 Tests are split into:
   - TestTransformationDataParsing  : __init__ / _parse_transformation_data
   - TestValidateProtocol           : _validate_protocol edge cases
+  - TestInitialTips                : initial_tip_p20 / initial_tip_p300 params
 """
 
 import unittest
@@ -255,6 +256,110 @@ class TestValidateProtocol(unittest.TestCase):
         self.assertEqual(len(t.competent_cell_tubes_by_chassis), 2)
         self.assertEqual(t.competent_cell_tubes_by_chassis['DH5alpha'], 1)
         self.assertEqual(t.competent_cell_tubes_by_chassis['BL21'], 1)
+
+
+# ---------------------------------------------------------------------------
+# 3. Initial tip parameters
+# ---------------------------------------------------------------------------
+
+class TestInitialTips(unittest.TestCase):
+    """
+    Tests for initial_tip_p20 and initial_tip_p300.
+
+    Attribute tests verify the full wiring:
+      __init__ param → kwargs_params → _merge_params → self.attribute
+
+    Assignment tests replicate the run() conditional logic with mock objects
+    to confirm starting_tip is set (or not set) correctly without needing a
+    full protocol context.
+    """
+
+    # --- Attribute wiring ---
+
+    def test_initial_tips_default_to_none(self):
+        """Both params must default to None when not provided."""
+        t = make_transformation(SINGLE_DH5ALPHA)
+        self.assertIsNone(t.initial_tip_p20)
+        self.assertIsNone(t.initial_tip_p300)
+
+    def test_initial_tip_p20_stored(self):
+        t = make_transformation(SINGLE_DH5ALPHA, initial_tip_p20='B1')
+        self.assertEqual(t.initial_tip_p20, 'B1')
+
+    def test_initial_tip_p300_stored(self):
+        t = make_transformation(SINGLE_DH5ALPHA, initial_tip_p300='C3')
+        self.assertEqual(t.initial_tip_p300, 'C3')
+
+    def test_both_initial_tips_set_independently(self):
+        """Setting both at once must not interfere with each other."""
+        t = make_transformation(SINGLE_DH5ALPHA, initial_tip_p20='A3', initial_tip_p300='D6')
+        self.assertEqual(t.initial_tip_p20, 'A3')
+        self.assertEqual(t.initial_tip_p300, 'D6')
+
+    def test_initial_tips_via_json_params(self):
+        """Params must be in valid_params so they can be set via json_params."""
+        t = make_transformation(
+            SINGLE_DH5ALPHA,
+            json_params={'initial_tip_p20': 'E1', 'initial_tip_p300': 'F2'}
+        )
+        self.assertEqual(t.initial_tip_p20, 'E1')
+        self.assertEqual(t.initial_tip_p300, 'F2')
+
+    # --- starting_tip assignment logic ---
+
+    def test_starting_tip_set_on_tiprack_when_provided(self):
+        """
+        When initial_tip_p20/p300 are set, starting_tip should be assigned
+        using tiprack[well_name]. Replicates the run() conditional with mocks.
+        """
+        t = make_transformation(SINGLE_DH5ALPHA, initial_tip_p20='B1', initial_tip_p300='C3')
+
+        mock_tiprack_p20 = MagicMock()
+        mock_tiprack_p300 = MagicMock()
+        mock_pipette_p20 = MagicMock()
+        mock_pipette_p300 = MagicMock()
+
+        if t.initial_tip_p20:
+            mock_pipette_p20.starting_tip = mock_tiprack_p20[t.initial_tip_p20]
+        if t.initial_tip_p300:
+            mock_pipette_p300.starting_tip = mock_tiprack_p300[t.initial_tip_p300]
+
+        mock_tiprack_p20.__getitem__.assert_called_once_with('B1')
+        mock_tiprack_p300.__getitem__.assert_called_once_with('C3')
+
+    def test_starting_tip_not_assigned_when_none(self):
+        """When initial_tip params are None, starting_tip must never be touched."""
+        t = make_transformation(SINGLE_DH5ALPHA)
+
+        mock_tiprack_p20 = MagicMock()
+        mock_tiprack_p300 = MagicMock()
+        mock_pipette_p20 = MagicMock()
+        mock_pipette_p300 = MagicMock()
+
+        if t.initial_tip_p20:
+            mock_pipette_p20.starting_tip = mock_tiprack_p20[t.initial_tip_p20]
+        if t.initial_tip_p300:
+            mock_pipette_p300.starting_tip = mock_tiprack_p300[t.initial_tip_p300]
+
+        mock_tiprack_p20.__getitem__.assert_not_called()
+        mock_tiprack_p300.__getitem__.assert_not_called()
+
+    def test_p20_tip_set_independently_of_p300(self):
+        """Setting only p20 must leave p300 starting_tip untouched."""
+        t = make_transformation(SINGLE_DH5ALPHA, initial_tip_p20='G6')
+
+        mock_tiprack_p20 = MagicMock()
+        mock_tiprack_p300 = MagicMock()
+        mock_pipette_p20 = MagicMock()
+        mock_pipette_p300 = MagicMock()
+
+        if t.initial_tip_p20:
+            mock_pipette_p20.starting_tip = mock_tiprack_p20[t.initial_tip_p20]
+        if t.initial_tip_p300:
+            mock_pipette_p300.starting_tip = mock_tiprack_p300[t.initial_tip_p300]
+
+        mock_tiprack_p20.__getitem__.assert_called_once_with('G6')
+        mock_tiprack_p300.__getitem__.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -295,6 +295,22 @@ class TestValidateProtocol(unittest.TestCase):
         t = make_transformation(SINGLE_DH5ALPHA)
         self._run_validate(t, num_wells=24)
 
+    def test_initial_dna_well_offset_included_in_capacity_check(self):
+        """
+        P2: initial_dna_well offset must be counted in the temp-module capacity check.
+        3 reagents (1 plasmid + 1 cell tube + 1 media tube) fit in 24 wells by raw count,
+        but starting at well 22 pushes the last reagent to well 24 — out of range.
+        """
+        t = make_transformation(SINGLE_DH5ALPHA, initial_dna_well=22)
+        with self.assertRaises(ValueError) as ctx:
+            self._run_validate(t, num_wells=24)
+        self.assertIn('more than', str(ctx.exception))
+
+    def test_initial_dna_well_offset_within_capacity_passes(self):
+        """A non-zero initial_dna_well that still fits within the block must not raise."""
+        t = make_transformation(SINGLE_DH5ALPHA, initial_dna_well=5)
+        self._run_validate(t, num_wells=24)  # 5 + 1 + 1 + 1 = 8 <= 24
+
     def test_multi_chassis_reagent_count(self):
         """
         Multi-chassis: each chassis gets its own cell tube(s).

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -171,6 +171,57 @@ class TestTransformationDataParsing(unittest.TestCase):
         self.assertEqual(t.all_chassis, ['DH5alpha'])
         self.assertEqual(t.all_plasmids, ['plasmid_1'])
 
+    def test_shared_plasmid_uri_across_transformations_passes(self):
+        """Same plasmid URI used in two different transformations is valid (shared source well)."""
+        t = make_transformation([
+            {
+                'Strain':  'https://SBOL2Build.org/strain_1/1',
+                'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+            },
+            {
+                'Strain':  'https://SBOL2Build.org/strain_2/1',
+                'Chassis': 'https://sbolcanvas.org/BL21/1',
+                'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']  # same URI
+            }
+        ])
+        # plasmid_1 appears only once — shared, not a collision
+        self.assertEqual(t.all_plasmids, ['plasmid_1'])
+
+    def test_colliding_plasmid_uris_raises(self):
+        """Two different URIs that extract to the same plasmid name must raise."""
+        with self.assertRaises(ValueError) as ctx:
+            make_transformation([
+                {
+                    'Strain':  'https://SBOL2Build.org/strain_1/1',
+                    'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                    'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+                },
+                {
+                    'Strain':  'https://SBOL2Build.org/strain_2/1',
+                    'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                    'Plasmids': ['https://SBOL2Build.org/plasmid_1/2']  # different URI, same name
+                }
+            ])
+        self.assertIn('plasmid_1', str(ctx.exception))
+
+    def test_colliding_chassis_uris_raises(self):
+        """Two different URIs that extract to the same chassis name must raise."""
+        with self.assertRaises(ValueError) as ctx:
+            make_transformation([
+                {
+                    'Strain':  'https://SBOL2Build.org/strain_1/1',
+                    'Chassis': 'https://sbolcanvas.org/DH5alpha/1',
+                    'Plasmids': ['https://SBOL2Build.org/plasmid_1/1']
+                },
+                {
+                    'Strain':  'https://SBOL2Build.org/strain_2/1',
+                    'Chassis': 'https://sbolcanvas.org/DH5alpha/2',  # different URI, same name
+                    'Plasmids': ['https://SBOL2Build.org/plasmid_2/1']
+                }
+            ])
+        self.assertIn('DH5alpha', str(ctx.exception))
+
 
 # ---------------------------------------------------------------------------
 # 2. _validate_protocol edge cases


### PR DESCRIPTION
transformation.py:
- Introduce self.plasmid_name_to_wells (name → [well_obj, ...]) populated at load time, replacing all positional/enumeration-based DNA well lookups
- Introduce self.location_replicates derived from plasmid_locations, unifying 96-well plate and temp module code paths into a single loop structure
- Rewrite _transfer_competent_cells with sequential well_index counter and per-chassis chassis_reaction_count dict for correct tube selection across multiple chassis types
- Rewrite _transfer_DNA as a unified single method with no plate/temp module branching; uses self.transformations as ground truth throughout
- _load_dna_into_dna_plate / _load_dna_into_temp_module now populate plasmid_name_to_wells instead of returning DNA_wells
- _load_reagents_96plate / _load_reagents_temp_module return 2-tuple; _validate_protocol accounts for location_replicates in reaction counts
- Add strain as first entry in dict_of_parts_in_thermocycler per well
- Rewrite Transformation base class docstring to match current parameters; add comprehensive HeatShockTransformation docstring for all subclass params

generate_protocol.py:
- Add generate_param_reference() to append a commented parameter table and full docstrings to every generated protocol for last-minute editing
- Add --plasmid-locations CLI flag and plasmid_locations support throughout
- Raise line-length threshold from 80 to 100 for single-line list formatting
- Improve transformation protocol auto-detection for bare list format

assembly.py:
- Initialize self.product_uri_to_wells = {}
