### PR TITLE
Add ManualAssembly to render Golden Gate manual protocols as Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ then in the OT-2 terminal run:
 ## Tutorials
 
 TODO
+
+## Manual Golden Gate protocol generation
+
+PUDU now supports generating a **human-readable manual Golden Gate protocol** from SBOL-style JSON input using `ManualAssembly`.
+
+- The class builds structured per-reaction records (product, backbone, ordered parts, enzyme, and calculated reagent volumes).
+- It renders a Markdown protocol suitable for lab use and future PDF conversion.
+- It does **not** generate OT-2 commands.
+
+Example script:
+
+```bash
+PYTHONPATH=src python scripts/generate_manual_assembly_protocol.py
+```
+
+This writes a protocol document to `scripts/manual_assembly_protocol.md`.

--- a/documentation/manual_assembly_protocol_example.md
+++ b/documentation/manual_assembly_protocol_example.md
@@ -1,0 +1,71 @@
+# Golden Gate Manual Assembly Protocol
+
+## Overview
+This document provides human-readable Golden Gate assembly instructions from SBOL-style JSON input.
+It is an instruction sheet for manual execution and is not an Opentrons OT-2 script.
+
+## Inputs
+- Number of target products: 2
+- `composite_1` (https://SBOL2Build.org/composite_1/1)
+- `composite_2` (https://SBOL2Build.org/composite_2/1)
+
+## Default reagent assumptions
+- Total reaction volume: 20 µL
+- Per DNA component volume (backbone or part): 2 µL
+- Restriction enzyme volume: 2 µL
+- T4 DNA ligase volume: 4 µL
+- T4 DNA ligase buffer volume: 2 µL
+- Water volume is calculated per reaction from the configured defaults.
+
+## Reaction summary
+| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | Water (µL) | Total (µL) |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 20 |
+| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 20 |
+
+## Per-reaction instructions
+
+### Product: composite_1
+URI: https://SBOL2Build.org/composite_1/1
+
+1. Label one tube as `composite_1`.
+2. Add 2 µL nuclease-free water.
+3. Add 2 µL 10X T4 DNA Ligase Buffer.
+4. Add 4 µL T4 DNA Ligase.
+5. Add 2 µL BsaI (URI: https://SBOL2Build.org/BsaI/1).
+6. Add 2 µL backbone `pSB1C3` (URI: https://sbolcanvas.org/pSB1C3/1).
+7. Add 2 µL part `J23101` (URI: https://sbolcanvas.org/J23101/1).
+8. Add 2 µL part `B0034` (URI: https://sbolcanvas.org/B0034/1).
+9. Add 2 µL part `GFP` (URI: https://sbolcanvas.org/GFP/1).
+10. Add 2 µL part `B0015` (URI: https://sbolcanvas.org/B0015/1).
+11. Mix gently by pipetting. Do not vortex unless explicitly intended.
+12. Briefly spin down if appropriate.
+
+### Product: composite_2
+URI: https://SBOL2Build.org/composite_2/1
+
+1. Label one tube as `composite_2`.
+2. Add 2 µL nuclease-free water.
+3. Add 2 µL 10X T4 DNA Ligase Buffer.
+4. Add 4 µL T4 DNA Ligase.
+5. Add 2 µL BsaI (URI: https://SBOL2Build.org/BsaI/1).
+6. Add 2 µL backbone `pSB1C3` (URI: https://sbolcanvas.org/pSB1C3/1).
+7. Add 2 µL part `J23106` (URI: https://sbolcanvas.org/J23106/1).
+8. Add 2 µL part `B0034` (URI: https://sbolcanvas.org/B0034/1).
+9. Add 2 µL part `RFP` (URI: https://sbolcanvas.org/RFP/1).
+10. Add 2 µL part `B0015` (URI: https://sbolcanvas.org/B0015/1).
+11. Mix gently by pipetting. Do not vortex unless explicitly intended.
+12. Briefly spin down if appropriate.
+
+## Thermocycling
+- Program a Golden Gate cycling profile suitable for your Type IIS enzyme and ligase system.
+- Typical high-level pattern:
+  - 25-35 cycles alternating between digestion and ligation temperatures.
+  - Follow with a final digestion/inactivation step as appropriate for enzyme cleanup.
+  - Hold at 4°C until samples are recovered.
+- Use your lab's validated Golden Gate settings for the selected restriction enzyme.
+
+## Notes
+- If the assembly was designed correctly, the final product should lack the Type IIS recognition sites used during assembly.
+- This generated document is a manual instruction sheet and not an automated OT-2 protocol.
+- Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume.

--- a/documentation/manual_assembly_protocol_example.md
+++ b/documentation/manual_assembly_protocol_example.md
@@ -1,27 +1,20 @@
 # Golden Gate Manual Assembly Protocol
 
 ## Overview
-This document provides human-readable Golden Gate assembly instructions from SBOL-style JSON input.
-It is an instruction sheet for manual execution and is not an Opentrons OT-2 script.
+Golden Gate assembly is a one-pot DNA cloning method that uses a Type IIS restriction enzyme, such as BsaI, together with DNA ligase to assemble multiple DNA fragments in a predefined order.
+Because Type IIS enzymes cut outside their recognition sites, they generate custom overhangs that direct fragment assembly and allow the recognition sites to be removed from the final construct.
+In this protocol, plasmids containing DNA parts and a destination backbone are combined with the restriction enzyme and ligase in a single tube, then cycled in a thermocycler between digestion and ligation temperatures. Repetition of these cycles enriches for the correctly assembled composite plasmid, after which the enzymes are heat-inactivated and the reaction is held at 4 °C until collection.
 
 ## Inputs
 - Number of target products: 2
 - `composite_1` (https://SBOL2Build.org/composite_1/1)
 - `composite_2` (https://SBOL2Build.org/composite_2/1)
 
-## Default reagent assumptions
-- Total reaction volume: 20 µL
-- Per DNA component volume (backbone or part): 2 µL
-- Restriction enzyme volume: 2 µL
-- T4 DNA ligase volume: 4 µL
-- T4 DNA ligase buffer volume: 2 µL
-- Water volume is calculated per reaction from the configured defaults.
-
 ## Reaction summary
-| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | Water (µL) | Total (µL) |
-| --- | --- | --- | --- | ---: | ---: | ---: |
-| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 20 |
-| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 20 |
+| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | DNA each (µL) | Enzyme (µL) | Ligase (µL) | Buffer (µL) | Water (µL) | Total (µL) |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 2 | 4 | 2 | 2 | 20 |
+| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 2 | 4 | 2 | 2 | 20 |
 
 ## Per-reaction instructions
 
@@ -58,14 +51,13 @@ URI: https://SBOL2Build.org/composite_2/1
 12. Briefly spin down if appropriate.
 
 ## Thermocycling
-- Program a Golden Gate cycling profile suitable for your Type IIS enzyme and ligase system.
-- Typical high-level pattern:
-  - 25-35 cycles alternating between digestion and ligation temperatures.
-  - Follow with a final digestion/inactivation step as appropriate for enzyme cleanup.
-  - Hold at 4°C until samples are recovered.
-- Use your lab's validated Golden Gate settings for the selected restriction enzyme.
+- Use a cycling profile that holds 42°C for 2 minutes and 16°C for 5 minutes; repeat this profile 75 times.
+- Denature/inactivate proteins by holding 60°C for 10 minutes followed by 80°C for 10 minutes.
+- Hold at 4°C until samples are collected.
 
 ## Notes
 - If the assembly was designed correctly, the final product should lack the Type IIS recognition sites used during assembly.
 - This generated document is a manual instruction sheet and not an automated OT-2 protocol.
 - Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume.
+- Store the assembly product at 4 °C for better stability until used for downstream applications.
+- Validate assembled plasmids by restriction digest and gel electrophoresis, Sanger sequencing, or whole-plasmid sequencing.

--- a/scripts/generate_manual_assembly_protocol.py
+++ b/scripts/generate_manual_assembly_protocol.py
@@ -1,0 +1,27 @@
+import json
+import argparse
+from pathlib import Path
+
+from pudu.assembly import ManualAssembly
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a manual Golden Gate Markdown protocol.")
+    parser.add_argument("--input", default="scripts/manual_assembly_input.json", help="Path to SBOL-style JSON input file.")
+    parser.add_argument("--output", default="scripts/manual_assembly_protocol.md", help="Path to Markdown output file.")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    assemblies = json.loads(input_path.read_text(encoding="utf-8"))
+
+    manual_protocol = ManualAssembly(assemblies=assemblies)
+    manual_protocol.process_assemblies()
+    manual_protocol.write_markdown(str(output_path))
+
+    print(f"Manual protocol written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/manual_assembly_input.json
+++ b/scripts/manual_assembly_input.json
@@ -1,0 +1,24 @@
+[
+    {
+        "Product": "https://SBOL2Build.org/composite_1/1",
+        "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+        "PartsList": [
+            "https://sbolcanvas.org/J23101/1",
+            "https://sbolcanvas.org/B0034/1",
+            "https://sbolcanvas.org/GFP/1",
+            "https://sbolcanvas.org/B0015/1"
+        ],
+        "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1"
+    },
+    {
+        "Product": "https://SBOL2Build.org/composite_2/1",
+        "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+        "PartsList": [
+            "https://sbolcanvas.org/J23106/1",
+            "https://sbolcanvas.org/B0034/1",
+            "https://sbolcanvas.org/RFP/1",
+            "https://sbolcanvas.org/B0015/1"
+        ],
+        "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1"
+    }
+]

--- a/scripts/manual_assembly_protocol.md
+++ b/scripts/manual_assembly_protocol.md
@@ -1,0 +1,71 @@
+# Golden Gate Manual Assembly Protocol
+
+## Overview
+This document provides human-readable Golden Gate assembly instructions from SBOL-style JSON input.
+It is an instruction sheet for manual execution and is not an Opentrons OT-2 script.
+
+## Inputs
+- Number of target products: 2
+- `composite_1` (https://SBOL2Build.org/composite_1/1)
+- `composite_2` (https://SBOL2Build.org/composite_2/1)
+
+## Default reagent assumptions
+- Total reaction volume: 20 µL
+- Per DNA component volume (backbone or part): 2 µL
+- Restriction enzyme volume: 2 µL
+- T4 DNA ligase volume: 4 µL
+- T4 DNA ligase buffer volume: 2 µL
+- Water volume is calculated per reaction from the configured defaults.
+
+## Reaction summary
+| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | Water (µL) | Total (µL) |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 20 |
+| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 20 |
+
+## Per-reaction instructions
+
+### Product: composite_1
+URI: https://SBOL2Build.org/composite_1/1
+
+1. Label one tube as `composite_1`.
+2. Add 2 µL nuclease-free water.
+3. Add 2 µL 10X T4 DNA Ligase Buffer.
+4. Add 4 µL T4 DNA Ligase.
+5. Add 2 µL BsaI (URI: https://SBOL2Build.org/BsaI/1).
+6. Add 2 µL backbone `pSB1C3` (URI: https://sbolcanvas.org/pSB1C3/1).
+7. Add 2 µL part `J23101` (URI: https://sbolcanvas.org/J23101/1).
+8. Add 2 µL part `B0034` (URI: https://sbolcanvas.org/B0034/1).
+9. Add 2 µL part `GFP` (URI: https://sbolcanvas.org/GFP/1).
+10. Add 2 µL part `B0015` (URI: https://sbolcanvas.org/B0015/1).
+11. Mix gently by pipetting. Do not vortex unless explicitly intended.
+12. Briefly spin down if appropriate.
+
+### Product: composite_2
+URI: https://SBOL2Build.org/composite_2/1
+
+1. Label one tube as `composite_2`.
+2. Add 2 µL nuclease-free water.
+3. Add 2 µL 10X T4 DNA Ligase Buffer.
+4. Add 4 µL T4 DNA Ligase.
+5. Add 2 µL BsaI (URI: https://SBOL2Build.org/BsaI/1).
+6. Add 2 µL backbone `pSB1C3` (URI: https://sbolcanvas.org/pSB1C3/1).
+7. Add 2 µL part `J23106` (URI: https://sbolcanvas.org/J23106/1).
+8. Add 2 µL part `B0034` (URI: https://sbolcanvas.org/B0034/1).
+9. Add 2 µL part `RFP` (URI: https://sbolcanvas.org/RFP/1).
+10. Add 2 µL part `B0015` (URI: https://sbolcanvas.org/B0015/1).
+11. Mix gently by pipetting. Do not vortex unless explicitly intended.
+12. Briefly spin down if appropriate.
+
+## Thermocycling
+- Program a Golden Gate cycling profile suitable for your Type IIS enzyme and ligase system.
+- Typical high-level pattern:
+  - 25-35 cycles alternating between digestion and ligation temperatures.
+  - Follow with a final digestion/inactivation step as appropriate for enzyme cleanup.
+  - Hold at 4°C until samples are recovered.
+- Use your lab's validated Golden Gate settings for the selected restriction enzyme.
+
+## Notes
+- If the assembly was designed correctly, the final product should lack the Type IIS recognition sites used during assembly.
+- This generated document is a manual instruction sheet and not an automated OT-2 protocol.
+- Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume.

--- a/scripts/manual_assembly_protocol.md
+++ b/scripts/manual_assembly_protocol.md
@@ -1,27 +1,20 @@
 # Golden Gate Manual Assembly Protocol
 
 ## Overview
-This document provides human-readable Golden Gate assembly instructions from SBOL-style JSON input.
-It is an instruction sheet for manual execution and is not an Opentrons OT-2 script.
+Golden Gate assembly is a one-pot DNA cloning method that uses a Type IIS restriction enzyme, such as BsaI, together with DNA ligase to assemble multiple DNA fragments in a predefined order.
+Because Type IIS enzymes cut outside their recognition sites, they generate custom overhangs that direct fragment assembly and allow the recognition sites to be removed from the final construct.
+In this protocol, plasmids containing DNA parts and a destination backbone are combined with the restriction enzyme and ligase in a single tube, then cycled in a thermocycler between digestion and ligation temperatures. Repetition of these cycles enriches for the correctly assembled composite plasmid, after which the enzymes are heat-inactivated and the reaction is held at 4 °C until collection.
 
 ## Inputs
 - Number of target products: 2
 - `composite_1` (https://SBOL2Build.org/composite_1/1)
 - `composite_2` (https://SBOL2Build.org/composite_2/1)
 
-## Default reagent assumptions
-- Total reaction volume: 20 µL
-- Per DNA component volume (backbone or part): 2 µL
-- Restriction enzyme volume: 2 µL
-- T4 DNA ligase volume: 4 µL
-- T4 DNA ligase buffer volume: 2 µL
-- Water volume is calculated per reaction from the configured defaults.
-
 ## Reaction summary
-| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | Water (µL) | Total (µL) |
-| --- | --- | --- | --- | ---: | ---: | ---: |
-| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 20 |
-| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 20 |
+| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | DNA each (µL) | Enzyme (µL) | Ligase (µL) | Buffer (µL) | Water (µL) | Total (µL) |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 2 | 4 | 2 | 2 | 20 |
+| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 2 | 4 | 2 | 2 | 20 |
 
 ## Per-reaction instructions
 
@@ -58,14 +51,13 @@ URI: https://SBOL2Build.org/composite_2/1
 12. Briefly spin down if appropriate.
 
 ## Thermocycling
-- Program a Golden Gate cycling profile suitable for your Type IIS enzyme and ligase system.
-- Typical high-level pattern:
-  - 25-35 cycles alternating between digestion and ligation temperatures.
-  - Follow with a final digestion/inactivation step as appropriate for enzyme cleanup.
-  - Hold at 4°C until samples are recovered.
-- Use your lab's validated Golden Gate settings for the selected restriction enzyme.
+- Use a cycling profile that holds 42°C for 2 minutes and 16°C for 5 minutes; repeat this profile 75 times.
+- Denature/inactivate proteins by holding 60°C for 10 minutes followed by 80°C for 10 minutes.
+- Hold at 4°C until samples are collected.
 
 ## Notes
 - If the assembly was designed correctly, the final product should lack the Type IIS recognition sites used during assembly.
 - This generated document is a manual instruction sheet and not an automated OT-2 protocol.
 - Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume.
+- Store the assembly product at 4 °C for better stability until used for downstream applications.
+- Validate assembled plasmids by restriction digest and gel electrophoresis, Sanger sequencing, or whole-plasmid sequencing.

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -1323,6 +1323,10 @@ class ManualAssembly(BaseAssembly):
                  assembly_data: Optional[Dict] = None,
                  json_params: Optional[str] = None,
                  assemblies: Optional[List[Dict]] = None,
+                 thermocycling_profile: Optional[List[Dict[str, float]]] = None,
+                 thermocycling_cycles: int = 75,
+                 denaturation_profile: Optional[List[Dict[str, float]]] = None,
+                 hold_temperature: float = 4,
                  *args, **kwargs):
         if assembly_data is not None:
             if isinstance(assembly_data, dict) and 'assemblies' in assembly_data:
@@ -1338,6 +1342,16 @@ class ManualAssembly(BaseAssembly):
         super().__init__(json_params=json_params, *args, **kwargs)
         self.assemblies = assemblies
         self.reaction_records: List[ManualReactionRecord] = []
+        self.thermocycling_profile = thermocycling_profile or [
+            {'temperature': 42, 'hold_time_minutes': 2},
+            {'temperature': 16, 'hold_time_minutes': 5}
+        ]
+        self.thermocycling_cycles = thermocycling_cycles
+        self.denaturation_profile = denaturation_profile or [
+            {'temperature': 60, 'hold_time_minutes': 10},
+            {'temperature': 80, 'hold_time_minutes': 10}
+        ]
+        self.hold_temperature = hold_temperature
 
     def process_assemblies(self):
         """Parse and validate input assemblies, then build reaction records."""
@@ -1468,15 +1482,25 @@ class ManualAssembly(BaseAssembly):
         return f"{int(value)}" if float(value).is_integer() else f"{value:.2f}"
 
     def _render_thermocycling_section(self) -> str:
-        """High-level Golden Gate thermocycling instructions. Can be parameterized later."""
+        """High-level Golden Gate thermocycling instructions."""
+        profile_descriptions = [
+            f"{step['temperature']}°C for {step['hold_time_minutes']} minutes"
+            for step in self.thermocycling_profile
+        ]
+        denaturation_descriptions = [
+            f"{step['temperature']}°C for {step['hold_time_minutes']} minutes"
+            for step in self.denaturation_profile
+        ]
+
+        profile_sentence = " and ".join(profile_descriptions)
+        denaturation_sentence = " followed by ".join(denaturation_descriptions)
+
         return (
             "## Thermocycling\n"
-            "- Program a Golden Gate cycling profile suitable for your Type IIS enzyme and ligase system.\n"
-            "- Typical high-level pattern:\n"
-            "  - 25-35 cycles alternating between digestion and ligation temperatures.\n"
-            "  - Follow with a final digestion/inactivation step as appropriate for enzyme cleanup.\n"
-            "  - Hold at 4°C until samples are recovered.\n"
-            "- Use your lab's validated Golden Gate settings for the selected restriction enzyme.\n"
+            f"- Use a cycling profile that holds {profile_sentence}; "
+            f"repeat this profile {self.thermocycling_cycles} times.\n"
+            f"- Denature/inactivate proteins by holding {denaturation_sentence}.\n"
+            f"- Hold at {self.hold_temperature}°C until samples are collected.\n"
         )
 
     def render_markdown(self) -> str:
@@ -1488,8 +1512,14 @@ class ManualAssembly(BaseAssembly):
             "# Golden Gate Manual Assembly Protocol",
             "",
             "## Overview",
-            "This document provides human-readable Golden Gate assembly instructions from SBOL-style JSON input.",
-            "It is an instruction sheet for manual execution and is not an Opentrons OT-2 script.",
+            "Golden Gate assembly is a one-pot DNA cloning method that uses a Type IIS restriction enzyme, "
+            "such as BsaI, together with DNA ligase to assemble multiple DNA fragments in a predefined order.",
+            "Because Type IIS enzymes cut outside their recognition sites, they generate custom overhangs that "
+            "direct fragment assembly and allow the recognition sites to be removed from the final construct.",
+            "In this protocol, plasmids containing DNA parts and a destination backbone are combined with the "
+            "restriction enzyme and ligase in a single tube, then cycled in a thermocycler between digestion and "
+            "ligation temperatures. Repetition of these cycles enriches for the correctly assembled composite "
+            "plasmid, after which the enzymes are heat-inactivated and the reaction is held at 4 °C until collection.",
             "",
             "## Inputs",
             f"- Number of target products: {len(self.reaction_records)}",
@@ -1499,23 +1529,17 @@ class ManualAssembly(BaseAssembly):
 
         lines.extend([
             "",
-            "## Default reagent assumptions",
-            f"- Total reaction volume: {self._fmt_volume(self.volume_total_reaction)} µL",
-            f"- Per DNA component volume (backbone or part): {self._fmt_volume(self.volume_part)} µL",
-            f"- Restriction enzyme volume: {self._fmt_volume(self.volume_restriction_enzyme)} µL",
-            f"- T4 DNA ligase volume: {self._fmt_volume(self.volume_t4_dna_ligase)} µL",
-            f"- T4 DNA ligase buffer volume: {self._fmt_volume(self.volume_t4_dna_ligase_buffer)} µL",
-            "- Water volume is calculated per reaction from the configured defaults.",
-            "",
             "## Reaction summary",
-            "| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | Water (µL) | Total (µL) |",
-            "| --- | --- | --- | --- | ---: | ---: | ---: |",
+            "| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | DNA each (µL) | Enzyme (µL) | Ligase (µL) | Buffer (µL) | Water (µL) | Total (µL) |",
+            "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
         ])
 
         for record in self.reaction_records:
             lines.append(
                 f"| {record.product_name} | {record.backbone_name} | {', '.join(record.part_names)} | "
                 f"{record.restriction_enzyme_name} | {record.number_of_dna_components} | "
+                f"{self._fmt_volume(self.volume_part)} | {self._fmt_volume(self.volume_restriction_enzyme)} | "
+                f"{self._fmt_volume(self.volume_t4_dna_ligase)} | {self._fmt_volume(self.volume_t4_dna_ligase_buffer)} | "
                 f"{self._fmt_volume(record.water_volume)} | {self._fmt_volume(record.total_reaction_volume)} |"
             )
 
@@ -1558,7 +1582,9 @@ class ManualAssembly(BaseAssembly):
             "## Notes",
             "- If the assembly was designed correctly, the final product should lack the Type IIS recognition sites used during assembly.",
             "- This generated document is a manual instruction sheet and not an automated OT-2 protocol.",
-            "- Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume."
+            "- Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume.",
+            "- Store the assembly product at 4 °C for better stability until used for downstream applications.",
+            "- Validate assembled plasmids by restriction digest and gel electrophoresis, Sanger sequencing, or whole-plasmid sequencing."
         ])
 
         return "\n".join(lines) + "\n"

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -5,7 +5,28 @@ from fnmatch import fnmatch
 from itertools import product
 import json
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from pudu.utils import Camera, colors
+
+
+@dataclass
+class ManualReactionRecord:
+    """Structured representation of one Golden Gate manual assembly reaction."""
+    product_uri: str
+    product_name: str
+    backbone_uri: str
+    backbone_name: str
+    part_uris: List[str]
+    part_names: List[str]
+    restriction_enzyme_uri: str
+    restriction_enzyme_name: str
+    number_of_dna_components: int
+    total_dna_volume: float
+    fixed_reagent_volume: float
+    water_volume: float
+    total_reaction_volume: float
+    reagent_additions: List[Dict[str, str]] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
 
 class BaseAssembly(ABC):
     """
@@ -1290,6 +1311,263 @@ class SBOLLoopAssembly(BaseAssembly):
         for assembly_combo in self.assembly_combinations:
             num_parts = len(assembly_combo['parts'])
             self._validate_reaction_volumes(num_parts)
+
+
+class ManualAssembly(BaseAssembly):
+    """
+    Manual Golden Gate assembly protocol generator from SBOL-style JSON input.
+    Produces structured reaction records and renders human-readable Markdown.
+    """
+
+    def __init__(self,
+                 assembly_data: Optional[Dict] = None,
+                 json_params: Optional[str] = None,
+                 assemblies: Optional[List[Dict]] = None,
+                 *args, **kwargs):
+        if assembly_data is not None:
+            if isinstance(assembly_data, dict) and 'assemblies' in assembly_data:
+                assemblies = assembly_data['assemblies']
+            else:
+                assemblies = assembly_data
+
+        if assemblies is None:
+            raise ValueError("Must provide assemblies either via assembly_data or assemblies parameter")
+        if not isinstance(assemblies, list) or not assemblies:
+            raise ValueError("assemblies must be a non-empty list of SBOL-style assembly dictionaries")
+
+        super().__init__(json_params=json_params, *args, **kwargs)
+        self.assemblies = assemblies
+        self.reaction_records: List[ManualReactionRecord] = []
+
+    def process_assemblies(self):
+        """Parse and validate input assemblies, then build reaction records."""
+        self._validate_input_assemblies()
+        self.reaction_records = self._build_reaction_records()
+        return self.reaction_records
+
+    def _load_parts_and_enzymes(self, protocol, alum_block) -> int:
+        raise NotImplementedError("ManualAssembly does not load reagents onto OT-2 modules.")
+
+    def _process_assembly_combinations(self, protocol, pipette, thermo_plate, alum_block,
+                                       dd_h2o, t4_dna_ligase_buffer, t4_dna_ligase,
+                                       volume_reagents, thermocycler_well_counter) -> int:
+        raise NotImplementedError("ManualAssembly does not generate OT-2 liquid handling commands.")
+
+    def _calculate_total_tips_needed(self, number_of_constant_reagents: int = 0) -> int:
+        return 0
+
+    def _validate_input_assemblies(self):
+        required_keys = {'Product', 'Backbone', 'PartsList', 'Restriction Enzyme'}
+
+        for idx, assembly in enumerate(self.assemblies, start=1):
+            if not isinstance(assembly, dict):
+                raise ValueError(f"Assembly #{idx} is not a dictionary.")
+
+            missing = required_keys - set(assembly.keys())
+            if missing:
+                raise ValueError(
+                    f"Assembly #{idx} is missing required keys: {sorted(missing)}. "
+                    f"Expected keys: {sorted(required_keys)}"
+                )
+
+            if not isinstance(assembly['PartsList'], list) or not assembly['PartsList']:
+                raise ValueError(f"Assembly #{idx} has an invalid 'PartsList'. Expected a non-empty list.")
+
+    def _extract_name_from_uri(self, uri: str) -> str:
+        """Extract display name from URI; falls back safely to raw input if needed."""
+        if not isinstance(uri, str):
+            return str(uri)
+
+        segments = [segment for segment in uri.rstrip('/').split('/') if segment]
+        if not segments:
+            return uri
+
+        if len(segments) >= 2 and segments[-1].isdigit():
+            return segments[-2]
+        return segments[-1]
+
+    def _calculate_reaction_volumes(self, number_of_dna_components: int) -> Dict[str, float]:
+        total_dna_volume = number_of_dna_components * self.volume_part
+        fixed_reagent_volume = (
+            self.volume_restriction_enzyme +
+            self.volume_t4_dna_ligase +
+            self.volume_t4_dna_ligase_buffer
+        )
+        water_volume = self.volume_total_reaction - fixed_reagent_volume - total_dna_volume
+
+        if water_volume < 0:
+            raise ValueError(
+                f"Reaction volume error: Cannot fit {number_of_dna_components} DNA components into "
+                f"{self.volume_total_reaction}µL reaction.\n"
+                f"  Required volumes:\n"
+                f"    - DNA ({number_of_dna_components} × {self.volume_part}µL): {total_dna_volume}µL\n"
+                f"    - Restriction enzyme: {self.volume_restriction_enzyme}µL\n"
+                f"    - T4 DNA ligase: {self.volume_t4_dna_ligase}µL\n"
+                f"    - T4 DNA ligase buffer: {self.volume_t4_dna_ligase_buffer}µL\n"
+                f"  Total required: {total_dna_volume + fixed_reagent_volume}µL"
+            )
+
+        return {
+            'total_dna_volume': total_dna_volume,
+            'fixed_reagent_volume': fixed_reagent_volume,
+            'water_volume': water_volume
+        }
+
+    def _build_reaction_records(self) -> List[ManualReactionRecord]:
+        records: List[ManualReactionRecord] = []
+        for assembly in self.assemblies:
+            product_uri = assembly["Product"]
+            backbone_uri = assembly["Backbone"]
+            part_uris = assembly["PartsList"]
+            enzyme_uri = assembly["Restriction Enzyme"]
+
+            product_name = self._extract_name_from_uri(product_uri)
+            backbone_name = self._extract_name_from_uri(backbone_uri)
+            part_names = [self._extract_name_from_uri(uri) for uri in part_uris]
+            enzyme_name = self._extract_name_from_uri(enzyme_uri)
+
+            number_of_dna_components = 1 + len(part_uris)
+            volume_data = self._calculate_reaction_volumes(number_of_dna_components)
+
+            reagent_additions = [
+                {'name': 'nuclease-free water', 'volume_uL': self._fmt_volume(volume_data['water_volume'])},
+                {'name': '10X T4 DNA Ligase Buffer', 'volume_uL': self._fmt_volume(self.volume_t4_dna_ligase_buffer)},
+                {'name': 'T4 DNA Ligase', 'volume_uL': self._fmt_volume(self.volume_t4_dna_ligase)},
+                {'name': enzyme_name, 'volume_uL': self._fmt_volume(self.volume_restriction_enzyme)},
+                {'name': f"backbone `{backbone_name}`", 'volume_uL': self._fmt_volume(self.volume_part)},
+            ]
+
+            for part_uri, part_name in zip(part_uris, part_names):
+                reagent_additions.append({
+                    'name': f"part `{part_name}`",
+                    'volume_uL': self._fmt_volume(self.volume_part),
+                    'uri': part_uri
+                })
+
+            record = ManualReactionRecord(
+                product_uri=product_uri,
+                product_name=product_name,
+                backbone_uri=backbone_uri,
+                backbone_name=backbone_name,
+                part_uris=part_uris,
+                part_names=part_names,
+                restriction_enzyme_uri=enzyme_uri,
+                restriction_enzyme_name=enzyme_name,
+                number_of_dna_components=number_of_dna_components,
+                total_dna_volume=volume_data['total_dna_volume'],
+                fixed_reagent_volume=volume_data['fixed_reagent_volume'],
+                water_volume=volume_data['water_volume'],
+                total_reaction_volume=self.volume_total_reaction,
+                reagent_additions=reagent_additions
+            )
+            records.append(record)
+
+        return records
+
+    def _fmt_volume(self, value: float) -> str:
+        return f"{int(value)}" if float(value).is_integer() else f"{value:.2f}"
+
+    def _render_thermocycling_section(self) -> str:
+        """High-level Golden Gate thermocycling instructions. Can be parameterized later."""
+        return (
+            "## Thermocycling\n"
+            "- Program a Golden Gate cycling profile suitable for your Type IIS enzyme and ligase system.\n"
+            "- Typical high-level pattern:\n"
+            "  - 25-35 cycles alternating between digestion and ligation temperatures.\n"
+            "  - Follow with a final digestion/inactivation step as appropriate for enzyme cleanup.\n"
+            "  - Hold at 4°C until samples are recovered.\n"
+            "- Use your lab's validated Golden Gate settings for the selected restriction enzyme.\n"
+        )
+
+    def render_markdown(self) -> str:
+        """Render a complete manual protocol in Markdown format."""
+        if not self.reaction_records:
+            self.process_assemblies()
+
+        lines = [
+            "# Golden Gate Manual Assembly Protocol",
+            "",
+            "## Overview",
+            "This document provides human-readable Golden Gate assembly instructions from SBOL-style JSON input.",
+            "It is an instruction sheet for manual execution and is not an Opentrons OT-2 script.",
+            "",
+            "## Inputs",
+            f"- Number of target products: {len(self.reaction_records)}",
+        ]
+        for record in self.reaction_records:
+            lines.append(f"- `{record.product_name}` ({record.product_uri})")
+
+        lines.extend([
+            "",
+            "## Default reagent assumptions",
+            f"- Total reaction volume: {self._fmt_volume(self.volume_total_reaction)} µL",
+            f"- Per DNA component volume (backbone or part): {self._fmt_volume(self.volume_part)} µL",
+            f"- Restriction enzyme volume: {self._fmt_volume(self.volume_restriction_enzyme)} µL",
+            f"- T4 DNA ligase volume: {self._fmt_volume(self.volume_t4_dna_ligase)} µL",
+            f"- T4 DNA ligase buffer volume: {self._fmt_volume(self.volume_t4_dna_ligase_buffer)} µL",
+            "- Water volume is calculated per reaction from the configured defaults.",
+            "",
+            "## Reaction summary",
+            "| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | Water (µL) | Total (µL) |",
+            "| --- | --- | --- | --- | ---: | ---: | ---: |",
+        ])
+
+        for record in self.reaction_records:
+            lines.append(
+                f"| {record.product_name} | {record.backbone_name} | {', '.join(record.part_names)} | "
+                f"{record.restriction_enzyme_name} | {record.number_of_dna_components} | "
+                f"{self._fmt_volume(record.water_volume)} | {self._fmt_volume(record.total_reaction_volume)} |"
+            )
+
+        lines.append("")
+        lines.append("## Per-reaction instructions")
+        lines.append("")
+
+        for record in self.reaction_records:
+            lines.append(f"### Product: {record.product_name}")
+            lines.append(f"URI: {record.product_uri}")
+            lines.append("")
+            lines.append(f"1. Label one tube as `{record.product_name}`.")
+            lines.append(f"2. Add {self._fmt_volume(record.water_volume)} µL nuclease-free water.")
+            lines.append(f"3. Add {self._fmt_volume(self.volume_t4_dna_ligase_buffer)} µL 10X T4 DNA Ligase Buffer.")
+            lines.append(f"4. Add {self._fmt_volume(self.volume_t4_dna_ligase)} µL T4 DNA Ligase.")
+            lines.append(
+                f"5. Add {self._fmt_volume(self.volume_restriction_enzyme)} µL "
+                f"{record.restriction_enzyme_name} (URI: {record.restriction_enzyme_uri})."
+            )
+            lines.append(
+                f"6. Add {self._fmt_volume(self.volume_part)} µL backbone "
+                f"`{record.backbone_name}` (URI: {record.backbone_uri})."
+            )
+
+            step_counter = 7
+            for part_name, part_uri in zip(record.part_names, record.part_uris):
+                lines.append(
+                    f"{step_counter}. Add {self._fmt_volume(self.volume_part)} µL part "
+                    f"`{part_name}` (URI: {part_uri})."
+                )
+                step_counter += 1
+
+            lines.append(f"{step_counter}. Mix gently by pipetting. Do not vortex unless explicitly intended.")
+            lines.append(f"{step_counter + 1}. Briefly spin down if appropriate.")
+            lines.append("")
+
+        lines.append(self._render_thermocycling_section().rstrip())
+        lines.extend([
+            "",
+            "## Notes",
+            "- If the assembly was designed correctly, the final product should lack the Type IIS recognition sites used during assembly.",
+            "- This generated document is a manual instruction sheet and not an automated OT-2 protocol.",
+            "- Assumes all DNA parts are available at suitable concentrations and added at equal per-part volume."
+        ])
+
+        return "\n".join(lines) + "\n"
+
+    def write_markdown(self, output_path: str):
+        """Write rendered Markdown protocol to disk."""
+        markdown = self.render_markdown()
+        with open(output_path, "w", encoding="utf-8") as file_handle:
+            file_handle.write(markdown)
 
 
 class LoopAssembly:

--- a/tests/test_manual_assembly.py
+++ b/tests/test_manual_assembly.py
@@ -50,9 +50,11 @@ class TestManualAssembly(unittest.TestCase):
 
         self.assertIn("# Golden Gate Manual Assembly Protocol", markdown)
         self.assertIn("## Reaction summary", markdown)
+        self.assertIn("DNA each (µL)", markdown)
         self.assertIn("### Product: composite_1", markdown)
         self.assertIn("Add 2 µL part `J23101`", markdown)
         self.assertIn("## Thermocycling", markdown)
+        self.assertIn("repeat this profile 75 times", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/test_manual_assembly.py
+++ b/tests/test_manual_assembly.py
@@ -1,0 +1,59 @@
+import unittest
+
+from pudu.assembly import ManualAssembly
+
+
+class TestManualAssembly(unittest.TestCase):
+    def setUp(self):
+        self.assemblies = [
+            {
+                "Product": "https://SBOL2Build.org/composite_1/1",
+                "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+                "PartsList": [
+                    "https://sbolcanvas.org/J23101/1",
+                    "https://sbolcanvas.org/B0034/1",
+                    "https://sbolcanvas.org/GFP/1",
+                    "https://sbolcanvas.org/B0015/1",
+                ],
+                "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1",
+            }
+        ]
+
+    def test_extract_name_from_uri(self):
+        assembly = ManualAssembly(assemblies=self.assemblies)
+        self.assertEqual(assembly._extract_name_from_uri("https://sbolcanvas.org/GFP/1"), "GFP")
+        self.assertEqual(assembly._extract_name_from_uri("https://SBOL2Build.org/composite_1/1"), "composite_1")
+
+    def test_volume_calculation(self):
+        assembly = ManualAssembly(assemblies=self.assemblies)
+        volumes = assembly._calculate_reaction_volumes(number_of_dna_components=5)
+        self.assertEqual(volumes["water_volume"], 2)
+        self.assertEqual(volumes["fixed_reagent_volume"], 8)
+        self.assertEqual(volumes["total_dna_volume"], 10)
+
+    def test_invalid_overfilled_reaction(self):
+        assembly = ManualAssembly(
+            assemblies=self.assemblies,
+            volume_total_reaction=10,
+            volume_part=2,
+            volume_restriction_enzyme=2,
+            volume_t4_dna_ligase=4,
+            volume_t4_dna_ligase_buffer=2,
+        )
+        with self.assertRaises(ValueError) as error:
+            assembly._calculate_reaction_volumes(number_of_dna_components=5)
+        self.assertIn("Cannot fit", str(error.exception))
+
+    def test_markdown_rendering_contains_sections_and_parts(self):
+        assembly = ManualAssembly(assemblies=self.assemblies)
+        markdown = assembly.render_markdown()
+
+        self.assertIn("# Golden Gate Manual Assembly Protocol", markdown)
+        self.assertIn("## Reaction summary", markdown)
+        self.assertIn("### Product: composite_1", markdown)
+        self.assertIn("Add 2 µL part `J23101`", markdown)
+        self.assertIn("## Thermocycling", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a manual (human-readable) Golden Gate assembly path that mirrors SBOL-style automated assemblies but emits Markdown instructions instead of OT-2 commands.
- Make it easy to produce lab instruction sheets (and later PDFs) from explicit SBOL-like JSON input while reusing BaseAssembly defaults and validation logic.

### Description
- Added `ManualReactionRecord` dataclass and a new `ManualAssembly(BaseAssembly)` class that parses SBOL-style JSON, validates inputs, extracts names from URIs, computes reaction volumes using `BaseAssembly` defaults, and builds structured reaction records.`
- Implemented volume logic and overfill validation in `_calculate_reaction_volumes`, and provided `render_markdown()` and `write_markdown()` to produce the requested Markdown structure including overview, inputs, reagent assumptions, reaction summary table, per-reaction instructions, thermocycling text, and notes.
- Exposed a small CLI example `scripts/generate_manual_assembly_protocol.py` with an example input `scripts/manual_assembly_input.json` and produced example outputs `scripts/manual_assembly_protocol.md` and `documentation/manual_assembly_protocol_example.md`.
- Added focused unit tests `tests/test_manual_assembly.py` for URI extraction, volume calculation, overfill validation, and Markdown content checks, and documented the feature in `README.md`.

### Testing
- Ran unit tests with `PYTHONPATH=src python -m pytest tests/test_manual_assembly.py`, all tests passed (4 passed).
- Executed the example generator with `PYTHONPATH=src python scripts/generate_manual_assembly_protocol.py`, which produced `scripts/manual_assembly_protocol.md` successfully.
- Verified bytecode compilation with `PYTHONPATH=src python -m compileall src/pudu scripts/generate_manual_assembly_protocol.py tests/test_manual_assembly.py`, which succeeded.
- Ran `ruff` which reported two `F841` warnings in an existing OT-2 assembly flow unrelated to `ManualAssembly` (these are pre-existing and not caused by the new feature).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47db6992c8330a310b2e239714b2e)