### PR TITLE
Add ManualAssembly class to generate Markdown Golden Gate protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ then in the OT-2 terminal run:
 
  Please visit our documentation with API reference at Read the Docs (TODO)
 
+## Manual Golden Gate protocol generation (Markdown)
+
+PUDU now includes a `ManualAssembly` class for Golden Gate workflows where you want an instruction sheet instead of an OT-2 script.
+
+```python
+from pudu.assembly import ManualAssembly
+
+assemblies = [
+    {
+        "Product": "https://SBOL2Build.org/composite_1/1",
+        "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+        "PartsList": [
+            "https://sbolcanvas.org/J23101/1",
+            "https://sbolcanvas.org/B0034/1",
+            "https://sbolcanvas.org/GFP/1",
+            "https://sbolcanvas.org/B0015/1"
+        ],
+        "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1"
+    }
+]
+
+manual_protocol = ManualAssembly(assemblies=assemblies, output_xlsx=False)
+markdown_text = manual_protocol.render_markdown()
+manual_protocol.write_markdown("manual_protocol.md")
+```
+
+You can run the end-to-end example in `examples/generate_manual_assembly_protocol.py`, which reads `examples/manual_assembly_input.json` and writes `documentation/manual_assembly_example.md`.
+
 ## Tutorials
 
 TODO

--- a/documentation/manual_assembly_example.md
+++ b/documentation/manual_assembly_example.md
@@ -1,0 +1,70 @@
+# Golden Gate Manual Assembly Protocol
+
+## Overview
+This document provides human-readable Golden Gate assembly instructions for constructs defined in SBOL-like JSON input.
+Each construct is treated as a separate reaction tube with explicit reagent additions and calculated water volumes.
+
+## Inputs
+- **composite_1** from `https://SBOL2Build.org/composite_1/1`
+- **composite_2** from `https://SBOL2Build.org/composite_2/1`
+
+## Default reagent assumptions
+- Total reaction volume: **20 µL**
+- Per DNA component volume (backbone and each part): **2 µL**
+- Restriction enzyme volume: **2 µL**
+- T4 DNA ligase volume: **4 µL**
+- T4 DNA ligase buffer volume: **2 µL**
+
+Calculated water volume per reaction:
+- **composite_1**: 2 µL
+- **composite_2**: 2 µL
+
+## Reaction summary
+| Product | Backbone | Parts | Restriction Enzyme | Number of DNA components | Water volume (µL) | Total volume (µL) |
+|---|---|---|---|---:|---:|---:|
+| composite_1 | pSB1C3 | J23101, B0034, GFP, B0015 | BsaI | 5 | 2 | 20 |
+| composite_2 | pSB1C3 | J23106, B0034, RFP, B0015 | BsaI | 5 | 2 | 20 |
+
+## Per-reaction instructions
+
+### Product: composite_1
+URI: https://SBOL2Build.org/composite_1/1
+
+1. Label one tube as `composite_1`.
+2. Add 2 µL nuclease-free water.
+3. Add 2 µL 10X T4 DNA Ligase Buffer.
+4. Add 4 µL T4 DNA Ligase.
+5. Add 2 µL BsaI (URI: https://SBOL2Build.org/BsaI/1).
+6. Add 2 µL backbone `pSB1C3` (URI: https://sbolcanvas.org/pSB1C3/1).
+7. Add 2 µL part `J23101` (URI: https://sbolcanvas.org/J23101/1).
+8. Add 2 µL part `B0034` (URI: https://sbolcanvas.org/B0034/1).
+9. Add 2 µL part `GFP` (URI: https://sbolcanvas.org/GFP/1).
+10. Add 2 µL part `B0015` (URI: https://sbolcanvas.org/B0015/1).
+11. Mix gently by pipetting. Do not vortex unless explicitly intended.
+12. Briefly spin down if appropriate.
+
+### Product: composite_2
+URI: https://SBOL2Build.org/composite_2/1
+
+1. Label one tube as `composite_2`.
+2. Add 2 µL nuclease-free water.
+3. Add 2 µL 10X T4 DNA Ligase Buffer.
+4. Add 4 µL T4 DNA Ligase.
+5. Add 2 µL BsaI (URI: https://SBOL2Build.org/BsaI/1).
+6. Add 2 µL backbone `pSB1C3` (URI: https://sbolcanvas.org/pSB1C3/1).
+7. Add 2 µL part `J23106` (URI: https://sbolcanvas.org/J23106/1).
+8. Add 2 µL part `B0034` (URI: https://sbolcanvas.org/B0034/1).
+9. Add 2 µL part `RFP` (URI: https://sbolcanvas.org/RFP/1).
+10. Add 2 µL part `B0015` (URI: https://sbolcanvas.org/B0015/1).
+11. Mix gently by pipetting. Do not vortex unless explicitly intended.
+12. Briefly spin down if appropriate.
+
+## Thermocycling
+1. Cycle 25–30 times between 37°C (digestion) and 16°C (ligation), typically 1–5 minutes at each temperature.
+2. Incubate at 50°C for 5 minutes to favor completion of assembled products.
+3. Heat inactivate at 80°C for 10 minutes, then hold at 4°C or place on ice.
+
+## Notes
+- If constructs are designed correctly, the final assembled product should no longer contain the Type IIS recognition sites used for assembly.
+- This generated document is an instruction sheet for manual execution and is not an automated OT-2 script.
+- Volumes for ligase, ligase buffer, enzyme, and DNA parts are taken from PUDU assembly defaults unless explicitly overridden.

--- a/examples/generate_manual_assembly_protocol.py
+++ b/examples/generate_manual_assembly_protocol.py
@@ -1,0 +1,21 @@
+"""Generate a manual Golden Gate protocol Markdown document from SBOL-like JSON input."""
+
+import json
+from pathlib import Path
+
+from pudu.assembly import ManualAssembly
+
+
+def main():
+    input_path = Path("examples/manual_assembly_input.json")
+    output_path = Path("documentation/manual_assembly_example.md")
+
+    assemblies = json.loads(input_path.read_text(encoding="utf-8"))
+    manual_protocol = ManualAssembly(assemblies=assemblies, output_xlsx=False)
+    manual_protocol.write_markdown(str(output_path))
+
+    print(f"Wrote manual protocol to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/manual_assembly_input.json
+++ b/examples/manual_assembly_input.json
@@ -1,0 +1,24 @@
+[
+  {
+    "Product": "https://SBOL2Build.org/composite_1/1",
+    "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+    "PartsList": [
+      "https://sbolcanvas.org/J23101/1",
+      "https://sbolcanvas.org/B0034/1",
+      "https://sbolcanvas.org/GFP/1",
+      "https://sbolcanvas.org/B0015/1"
+    ],
+    "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1"
+  },
+  {
+    "Product": "https://SBOL2Build.org/composite_2/1",
+    "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+    "PartsList": [
+      "https://sbolcanvas.org/J23106/1",
+      "https://sbolcanvas.org/B0034/1",
+      "https://sbolcanvas.org/RFP/1",
+      "https://sbolcanvas.org/B0015/1"
+    ],
+    "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1"
+  }
+]

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -1,11 +1,32 @@
 import xlsxwriter
 from opentrons import protocol_api
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 from fnmatch import fnmatch
 from itertools import product
 import json
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from pudu.utils import Camera, colors
+
+
+@dataclass
+class ManualReactionRecord:
+    """Structured representation of a single manual assembly reaction."""
+    product_uri: str
+    product_name: str
+    backbone_uri: str
+    backbone_name: str
+    part_uris: List[str]
+    part_names: List[str]
+    restriction_enzyme_uri: str
+    restriction_enzyme_name: str
+    reagent_additions: List[Dict[str, Any]] = field(default_factory=list)
+    number_of_dna_components: int = 0
+    total_dna_volume: float = 0.0
+    fixed_reagent_volume: float = 0.0
+    water_volume: float = 0.0
+    total_reaction_volume: float = 0.0
+    notes: List[str] = field(default_factory=list)
 
 class BaseAssembly(ABC):
     """
@@ -220,6 +241,16 @@ class BaseAssembly(ABC):
                 f"    2. Decrease 'volume_part' to at most {(self.volume_total_reaction - volume_reagents - 1) / num_parts:.1f}µL\n"
                 f"    3. Decrease reagent volumes"
             )
+
+    def _extract_name_from_uri(self, uri: str) -> str:
+        """Extract a resource name from a URI-like identifier."""
+        if not isinstance(uri, str) or not uri.strip():
+            raise ValueError(f"Invalid URI value: {uri!r}")
+
+        chunks = [chunk for chunk in uri.strip().split('/') if chunk]
+        if len(chunks) >= 2:
+            return chunks[-2]
+        return chunks[-1]
 
     def _well_to_index(self, well_name: str) -> int:
         """
@@ -1248,17 +1279,6 @@ class SBOLLoopAssembly(BaseAssembly):
         self.combined_set = set()
         self.assembly_combinations = []
 
-    def _extract_name_from_uri(self, uri: str) -> str:
-        """Extract part name from SBOL URI"""
-        # Extract the last segment after the last '/'
-        if '/' in uri:
-            name_with_version = uri.split('/')[-2]
-            # Remove version number if present (e.g., "GFP/1" -> "GFP")
-            if '/' in name_with_version:
-                return name_with_version.split('/')[0]
-            return name_with_version
-        return uri
-
     def _validate_assembly_requirements(self):
         """Validate SBOL assembly requirements"""
         if not self.assembly_combinations:
@@ -1290,6 +1310,218 @@ class SBOLLoopAssembly(BaseAssembly):
         for assembly_combo in self.assembly_combinations:
             num_parts = len(assembly_combo['parts'])
             self._validate_reaction_volumes(num_parts)
+
+
+class ManualAssembly(BaseAssembly):
+    """
+    Manual Golden Gate assembly protocol generator.
+    Generates human-readable Markdown instead of Opentrons commands.
+    """
+
+    def __init__(self,
+                 assembly_data: Optional[Dict] = None,
+                 json_params: Optional[str] = None,
+                 assemblies: Optional[List[Dict]] = None,
+                 thermocycling_steps: Optional[List[str]] = None,
+                 *args, **kwargs):
+        if assembly_data is not None:
+            if isinstance(assembly_data, dict) and 'assemblies' in assembly_data:
+                assemblies = assembly_data['assemblies']
+            else:
+                assemblies = assembly_data
+
+        if assemblies is None:
+            raise ValueError("Must provide assemblies either via assembly_data or assemblies parameter")
+        if not isinstance(assemblies, list):
+            raise ValueError("assemblies must be a list of reaction dictionaries")
+
+        super().__init__(json_params=json_params, *args, **kwargs)
+        self.assemblies = assemblies
+        self.reaction_records: List[ManualReactionRecord] = []
+        self.required_keys = {'Product', 'Backbone', 'PartsList', 'Restriction Enzyme'}
+        self.thermocycling_steps = thermocycling_steps or [
+            "Cycle 25–30 times between 37°C (digestion) and 16°C (ligation), typically 1–5 minutes at each temperature.",
+            "Incubate at 50°C for 5 minutes to favor completion of assembled products.",
+            "Heat inactivate at 80°C for 10 minutes, then hold at 4°C or place on ice."
+        ]
+
+    def process_assemblies(self):
+        self.reaction_records = self._build_reaction_records()
+        return self.reaction_records
+
+    def _load_parts_and_enzymes(self, protocol, alum_block) -> int:
+        raise NotImplementedError("ManualAssembly does not load Opentrons labware.")
+
+    def _process_assembly_combinations(self, protocol, pipette, thermo_plate, alum_block,
+                                       dd_h2o, t4_dna_ligase_buffer, t4_dna_ligase,
+                                       volume_reagents, thermocycler_well_counter) -> int:
+        raise NotImplementedError("ManualAssembly does not generate Opentrons commands.")
+
+    def _calculate_total_tips_needed(self) -> int:
+        return 0
+
+    def _build_reaction_records(self) -> List[ManualReactionRecord]:
+        if not self.assemblies:
+            raise ValueError("No assemblies provided")
+
+        reaction_records = []
+        for index, assembly in enumerate(self.assemblies, start=1):
+            self._validate_assembly_entry(assembly, index)
+            part_uris = assembly["PartsList"]
+
+            record = ManualReactionRecord(
+                product_uri=assembly["Product"],
+                product_name=self._extract_name_from_uri(assembly["Product"]),
+                backbone_uri=assembly["Backbone"],
+                backbone_name=self._extract_name_from_uri(assembly["Backbone"]),
+                part_uris=part_uris,
+                part_names=[self._extract_name_from_uri(part_uri) for part_uri in part_uris],
+                restriction_enzyme_uri=assembly["Restriction Enzyme"],
+                restriction_enzyme_name=self._extract_name_from_uri(assembly["Restriction Enzyme"]),
+            )
+
+            self._calculate_reaction_volumes(record)
+            record.reagent_additions = self._build_reagent_additions(record)
+            reaction_records.append(record)
+
+        return reaction_records
+
+    def _validate_assembly_entry(self, assembly: Dict[str, Any], index: int):
+        if not isinstance(assembly, dict):
+            raise ValueError(f"Assembly #{index} must be a dictionary")
+
+        missing = self.required_keys - set(assembly.keys())
+        if missing:
+            raise ValueError(
+                f"Assembly #{index} is missing required keys: {sorted(missing)}. "
+                f"Expected keys: {sorted(self.required_keys)}"
+            )
+
+        if not isinstance(assembly["PartsList"], list) or not assembly["PartsList"]:
+            raise ValueError(f"Assembly #{index} must include a non-empty PartsList")
+
+    def _calculate_reaction_volumes(self, record: ManualReactionRecord):
+        record.number_of_dna_components = 1 + len(record.part_names)  # backbone + parts
+        self._validate_reaction_volumes(record.number_of_dna_components)
+
+        record.total_dna_volume = record.number_of_dna_components * self.volume_part
+        record.fixed_reagent_volume = (
+            self.volume_restriction_enzyme +
+            self.volume_t4_dna_ligase +
+            self.volume_t4_dna_ligase_buffer
+        )
+        record.total_reaction_volume = self.volume_total_reaction
+        record.water_volume = (
+            record.total_reaction_volume - record.fixed_reagent_volume - record.total_dna_volume
+        )
+
+        if record.water_volume < 0:
+            raise ValueError(
+                f"Reaction '{record.product_name}' cannot fit in {self.volume_total_reaction}µL. "
+                f"Calculated water volume is {record.water_volume}µL."
+            )
+
+    def _build_reagent_additions(self, record: ManualReactionRecord) -> List[Dict[str, Any]]:
+        additions = [
+            {"name": "nuclease-free water", "volume": record.water_volume},
+            {"name": "10X T4 DNA Ligase Buffer", "volume": self.volume_t4_dna_ligase_buffer},
+            {"name": "T4 DNA Ligase", "volume": self.volume_t4_dna_ligase},
+            {"name": record.restriction_enzyme_name, "volume": self.volume_restriction_enzyme,
+             "uri": record.restriction_enzyme_uri},
+            {"name": f"backbone `{record.backbone_name}`", "volume": self.volume_part, "uri": record.backbone_uri}
+        ]
+
+        for part_name, part_uri in zip(record.part_names, record.part_uris):
+            additions.append({"name": f"part `{part_name}`", "volume": self.volume_part, "uri": part_uri})
+
+        return additions
+
+    def render_markdown(self) -> str:
+        if not self.reaction_records:
+            self.process_assemblies()
+
+        lines = [
+            "# Golden Gate Manual Assembly Protocol",
+            "",
+            "## Overview",
+            "This document provides human-readable Golden Gate assembly instructions for constructs defined in SBOL-like JSON input.",
+            "Each construct is treated as a separate reaction tube with explicit reagent additions and calculated water volumes.",
+            "",
+            "## Inputs",
+        ]
+
+        for record in self.reaction_records:
+            lines.append(f"- **{record.product_name}** from `{record.product_uri}`")
+
+        lines.extend([
+            "",
+            "## Default reagent assumptions",
+            f"- Total reaction volume: **{self.volume_total_reaction} µL**",
+            f"- Per DNA component volume (backbone and each part): **{self.volume_part} µL**",
+            f"- Restriction enzyme volume: **{self.volume_restriction_enzyme} µL**",
+            f"- T4 DNA ligase volume: **{self.volume_t4_dna_ligase} µL**",
+            f"- T4 DNA ligase buffer volume: **{self.volume_t4_dna_ligase_buffer} µL**",
+            "",
+            "Calculated water volume per reaction:",
+        ])
+        for record in self.reaction_records:
+            lines.append(f"- **{record.product_name}**: {record.water_volume} µL")
+
+        lines.extend([
+            "",
+            "## Reaction summary",
+            "| Product | Backbone | Parts | Restriction Enzyme | Number of DNA components | Water volume (µL) | Total volume (µL) |",
+            "|---|---|---|---|---:|---:|---:|",
+        ])
+        for record in self.reaction_records:
+            part_text = ", ".join(record.part_names)
+            lines.append(
+                f"| {record.product_name} | {record.backbone_name} | {part_text} | "
+                f"{record.restriction_enzyme_name} | {record.number_of_dna_components} | "
+                f"{record.water_volume} | {record.total_reaction_volume} |"
+            )
+
+        lines.extend(["", "## Per-reaction instructions", ""])
+        for record in self.reaction_records:
+            lines.extend([
+                f"### Product: {record.product_name}",
+                f"URI: {record.product_uri}",
+                "",
+                f"1. Label one tube as `{record.product_name}`.",
+            ])
+
+            step_index = 2
+            for addition in record.reagent_additions:
+                line = f"{step_index}. Add {addition['volume']} µL {addition['name']}"
+                if 'uri' in addition:
+                    line += f" (URI: {addition['uri']})"
+                line += "."
+                lines.append(line)
+                step_index += 1
+
+            lines.extend([
+                f"{step_index}. Mix gently by pipetting. Do not vortex unless explicitly intended.",
+                f"{step_index + 1}. Briefly spin down if appropriate.",
+                ""
+            ])
+
+        lines.extend(["## Thermocycling"])
+        for i, step in enumerate(self.thermocycling_steps, start=1):
+            lines.append(f"{i}. {step}")
+
+        lines.extend([
+            "",
+            "## Notes",
+            "- If constructs are designed correctly, the final assembled product should no longer contain the Type IIS recognition sites used for assembly.",
+            "- This generated document is an instruction sheet for manual execution and is not an automated OT-2 script.",
+            "- Volumes for ligase, ligase buffer, enzyme, and DNA parts are taken from PUDU assembly defaults unless explicitly overridden.",
+        ])
+
+        return "\n".join(lines)
+
+    def write_markdown(self, output_path: str):
+        with open(output_path, "w", encoding="utf-8") as handle:
+            handle.write(self.render_markdown())
 
 
 class LoopAssembly:

--- a/tests/test_manual_assembly.py
+++ b/tests/test_manual_assembly.py
@@ -1,0 +1,69 @@
+import unittest
+
+from pudu.assembly import ManualAssembly
+
+
+EXAMPLE_ASSEMBLIES = [
+    {
+        "Product": "https://SBOL2Build.org/composite_1/1",
+        "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+        "PartsList": [
+            "https://sbolcanvas.org/J23101/1",
+            "https://sbolcanvas.org/B0034/1",
+            "https://sbolcanvas.org/GFP/1",
+            "https://sbolcanvas.org/B0015/1",
+        ],
+        "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1",
+    },
+    {
+        "Product": "https://SBOL2Build.org/composite_2/1",
+        "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+        "PartsList": [
+            "https://sbolcanvas.org/J23106/1",
+            "https://sbolcanvas.org/B0034/1",
+            "https://sbolcanvas.org/RFP/1",
+            "https://sbolcanvas.org/B0015/1",
+        ],
+        "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1",
+    },
+]
+
+
+class TestManualAssembly(unittest.TestCase):
+    def test_extract_name_from_uri(self):
+        protocol = ManualAssembly(assemblies=EXAMPLE_ASSEMBLIES, output_xlsx=False)
+        self.assertEqual(protocol._extract_name_from_uri("https://sbolcanvas.org/GFP/1"), "GFP")
+
+    def test_volume_calculation(self):
+        protocol = ManualAssembly(assemblies=EXAMPLE_ASSEMBLIES, output_xlsx=False)
+        records = protocol.process_assemblies()
+
+        first = records[0]
+        self.assertEqual(first.number_of_dna_components, 5)
+        self.assertEqual(first.water_volume, 2)
+        self.assertEqual(first.total_reaction_volume, 20)
+
+    def test_invalid_overfilled_reaction(self):
+        overfilled = [{
+            "Product": "https://SBOL2Build.org/composite_1/1",
+            "Backbone": "https://sbolcanvas.org/pSB1C3/1",
+            "PartsList": [f"https://example.org/part_{i}/1" for i in range(12)],
+            "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1",
+        }]
+
+        protocol = ManualAssembly(assemblies=overfilled, output_xlsx=False)
+        with self.assertRaises(ValueError):
+            protocol.process_assemblies()
+
+    def test_markdown_rendering_contains_sections(self):
+        protocol = ManualAssembly(assemblies=EXAMPLE_ASSEMBLIES, output_xlsx=False)
+        markdown = protocol.render_markdown()
+
+        self.assertIn("# Golden Gate Manual Assembly Protocol", markdown)
+        self.assertIn("## Per-reaction instructions", markdown)
+        self.assertIn("### Product: composite_1", markdown)
+        self.assertIn("Add 2 µL nuclease-free water", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a manual (human-readable) protocol output path for Golden Gate assemblies defined in SBOL-like JSON without emitting Opentrons commands. 
- Reuse existing assembly defaults and validation logic so manual protocols stay consistent with automated assembly parameters.
- Produce Markdown-first output so protocols can be converted to PDF later and be easily reviewed by users.

### Description
- Added a `ManualReactionRecord` dataclass to model each reaction and moved a reusable URI name extractor into `BaseAssembly` as `_extract_name_from_uri` for shared identifier handling. 
- Implemented `ManualAssembly(BaseAssembly)` which parses and validates SBOL-like JSON assemblies, builds structured reaction records, calculates DNA/reagent/water volumes using `BaseAssembly` defaults, and raises clear errors for overfilled reactions. 
- Implemented Markdown rendering with `render_markdown()` and `write_markdown()` that output: title, overview, inputs, default reagent assumptions, reaction summary table, per-reaction pipetting instructions, thermocycling section, and notes. 
- Kept robot-specific hooks disabled for this class by raising `NotImplementedError` for Opentrons-specific abstract methods and added a small example generator and sample JSON input plus a generated reference Markdown file. 
- Files added/modified: `src/pudu/assembly.py` (new dataclass, URI helper, `ManualAssembly`), `tests/test_manual_assembly.py` (unit tests), `examples/generate_manual_assembly_protocol.py`, `examples/manual_assembly_input.json`, `documentation/manual_assembly_example.md`, and README updated with usage snippet.

### Testing
- Ran unit tests: `PYTHONPATH=src pytest -q tests/test_manual_assembly.py` — 4 tests passed (`4 passed`).
- Ran static checks on the new example and test files: `PYTHONPATH=src python -m ruff check tests/test_manual_assembly.py examples/generate_manual_assembly_protocol.py` — checks passed for those files. 
- Verified bytecode compilation: `PYTHONPATH=src python -m py_compile src/pudu/assembly.py` — compilation succeeded. 
- Executed end-to-end example: `PYTHONPATH=src python examples/generate_manual_assembly_protocol.py` which wrote `documentation/manual_assembly_example.md` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47db6992c8330a310b2e239714b2e)