### PR TITLE
Improve ManualAssembly markdown protocol formatting and links

### DIFF
--- a/scripts/generate_manual_plating_protocol.py
+++ b/scripts/generate_manual_plating_protocol.py
@@ -1,0 +1,27 @@
+import json
+import argparse
+from pathlib import Path
+
+from pudu.plating import ManualPlating
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a manual plating Markdown protocol.")
+    parser.add_argument("--input", default="scripts/plating_input.json", help="Path to plating JSON input file.")
+    parser.add_argument("--output", default="scripts/manual_plating_protocol.md", help="Path to Markdown output file.")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    plating_data = json.loads(input_path.read_text(encoding="utf-8"))
+
+    manual_protocol = ManualPlating(plating_data=plating_data)
+    manual_protocol.process_bacterium_locations()
+    manual_protocol.write_markdown(str(output_path))
+
+    print(f"Manual plating protocol written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_manual_transformation_protocol.py
+++ b/scripts/generate_manual_transformation_protocol.py
@@ -1,0 +1,27 @@
+import json
+import argparse
+from pathlib import Path
+
+from pudu.transformation import ManualTransformation
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a manual heat-shock transformation Markdown protocol.")
+    parser.add_argument("--input", default="scripts/manual_transformation_input.json", help="Path to SBOL-style JSON input file.")
+    parser.add_argument("--output", default="scripts/manual_transformation_protocol.md", help="Path to Markdown output file.")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    transformations = json.loads(input_path.read_text(encoding="utf-8"))
+
+    manual_protocol = ManualTransformation(transformation_data=transformations)
+    manual_protocol.process_transformations()
+    manual_protocol.write_markdown(str(output_path))
+
+    print(f"Manual transformation protocol written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -1343,14 +1343,14 @@ class ManualAssembly(BaseAssembly):
         self.assemblies = assemblies
         self.reaction_records: List[ManualReactionRecord] = []
         self.thermocycling_profile = thermocycling_profile or [
-            {'temperature': 42, 'hold_time_minutes': 2},
-            {'temperature': 16, 'hold_time_minutes': 5}
+            {'step': 'Digest', 'temperature': 37, 'hold_time_minutes': 2, 'cycles': 25},
+            {'step': 'Ligate', 'temperature': 16, 'hold_time_minutes': 5, 'cycles': 25},
+            {'step': 'Final digestion', 'temperature': 50, 'hold_time_minutes': 5, 'cycles': 1},
+            {'step': 'Heat inactivation', 'temperature': 80, 'hold_time_minutes': 10, 'cycles': 1},
+            {'step': 'Hold', 'temperature': 4, 'hold_time_minutes': 'indefinite', 'cycles': 1},
         ]
         self.thermocycling_cycles = thermocycling_cycles
-        self.denaturation_profile = denaturation_profile or [
-            {'temperature': 60, 'hold_time_minutes': 10},
-            {'temperature': 80, 'hold_time_minutes': 10}
-        ]
+        self.denaturation_profile = denaturation_profile or []
         self.hold_temperature = hold_temperature
 
     def process_assemblies(self):
@@ -1387,18 +1387,45 @@ class ManualAssembly(BaseAssembly):
             if not isinstance(assembly['PartsList'], list) or not assembly['PartsList']:
                 raise ValueError(f"Assembly #{idx} has an invalid 'PartsList'. Expected a non-empty list.")
 
-    def _extract_name_from_uri(self, uri: str) -> str:
-        """Extract display name from URI; falls back safely to raw input if needed."""
-        if not isinstance(uri, str):
-            return str(uri)
-
-        segments = [segment for segment in uri.rstrip('/').split('/') if segment]
-        if not segments:
-            return uri
-
+    def _extract_name_from_uri(self, value) -> str:
+        """Extract human-readable names from dictionaries, URIs, or plain values."""
+        if isinstance(value, dict):
+            for key in ("displayId", "display_id", "name", "label"):
+                if value.get(key):
+                    return value[key]
+        uri = self._extract_uri(value) or value
+        if not uri:
+            return "Unknown"
+        segments = [segment for segment in str(uri).rstrip('/').split('/') if segment]
         if len(segments) >= 2 and segments[-1].isdigit():
             return segments[-2]
-        return segments[-1]
+        return segments[-1] if segments else "Unknown"
+
+    def _extract_uri(self, value) -> Optional[str]:
+        if isinstance(value, dict):
+            for key in (
+                "Implementation",
+                "implementation",
+                "implementation_uri",
+                "implementationUri",
+                "Implementation URI",
+                "uri",
+                "URI",
+                "identity",
+            ):
+                if value.get(key):
+                    return value[key]
+            return None
+        if isinstance(value, str) and value.startswith(("http://", "https://")):
+            return value
+        return None
+
+    def _markdown_link(self, label: str, uri: Optional[str]) -> str:
+        if not uri:
+            return label
+        escaped_label = str(label).replace("[", "\\[").replace("]", "\\]")
+        escaped_uri = str(uri).replace(")", "%29").replace(" ", "%20")
+        return f"[{escaped_label}]({escaped_uri})"
 
     def _calculate_reaction_volumes(self, number_of_dna_components: int) -> Dict[str, float]:
         total_dna_volume = number_of_dna_components * self.volume_part
@@ -1430,10 +1457,10 @@ class ManualAssembly(BaseAssembly):
     def _build_reaction_records(self) -> List[ManualReactionRecord]:
         records: List[ManualReactionRecord] = []
         for assembly in self.assemblies:
-            product_uri = assembly["Product"]
-            backbone_uri = assembly["Backbone"]
+            product_uri = self._extract_uri(assembly["Product"]) or str(assembly["Product"])
+            backbone_uri = self._extract_uri(assembly["Backbone"]) or str(assembly["Backbone"])
             part_uris = assembly["PartsList"]
-            enzyme_uri = assembly["Restriction Enzyme"]
+            enzyme_uri = self._extract_uri(assembly["Restriction Enzyme"]) or str(assembly["Restriction Enzyme"])
 
             product_name = self._extract_name_from_uri(product_uri)
             backbone_name = self._extract_name_from_uri(backbone_uri)
@@ -1445,17 +1472,17 @@ class ManualAssembly(BaseAssembly):
 
             reagent_additions = [
                 {'name': 'nuclease-free water', 'volume_uL': self._fmt_volume(volume_data['water_volume'])},
-                {'name': '10X T4 DNA Ligase Buffer', 'volume_uL': self._fmt_volume(self.volume_t4_dna_ligase_buffer)},
+                {'name': 'T4 DNA ligase buffer', 'volume_uL': self._fmt_volume(self.volume_t4_dna_ligase_buffer)},
                 {'name': 'T4 DNA Ligase', 'volume_uL': self._fmt_volume(self.volume_t4_dna_ligase)},
-                {'name': enzyme_name, 'volume_uL': self._fmt_volume(self.volume_restriction_enzyme)},
-                {'name': f"backbone `{backbone_name}`", 'volume_uL': self._fmt_volume(self.volume_part)},
+                {'name': f"{enzyme_name} restriction enzyme", 'volume_uL': self._fmt_volume(self.volume_restriction_enzyme)},
+                {'name': backbone_name, 'volume_uL': self._fmt_volume(self.volume_part), 'uri': backbone_uri},
             ]
 
             for part_uri, part_name in zip(part_uris, part_names):
                 reagent_additions.append({
-                    'name': f"part `{part_name}`",
+                    'name': part_name,
                     'volume_uL': self._fmt_volume(self.volume_part),
-                    'uri': part_uri
+                    'uri': self._extract_uri(part_uri)
                 })
 
             record = ManualReactionRecord(
@@ -1481,27 +1508,19 @@ class ManualAssembly(BaseAssembly):
     def _fmt_volume(self, value: float) -> str:
         return f"{int(value)}" if float(value).is_integer() else f"{value:.2f}"
 
-    def _render_thermocycling_section(self) -> str:
-        """High-level Golden Gate thermocycling instructions."""
-        profile_descriptions = [
-            f"{step['temperature']}°C for {step['hold_time_minutes']} minutes"
-            for step in self.thermocycling_profile
+    def _render_thermocycling_section(self) -> List[str]:
+        lines = [
+            "## Thermocycler Program",
+            "",
+            "| Step | Temperature | Time | Cycles |",
+            "| --- | --- | --- | ---: |",
         ]
-        denaturation_descriptions = [
-            f"{step['temperature']}°C for {step['hold_time_minutes']} minutes"
-            for step in self.denaturation_profile
-        ]
-
-        profile_sentence = " and ".join(profile_descriptions)
-        denaturation_sentence = " followed by ".join(denaturation_descriptions)
-
-        return (
-            "## Thermocycling\n"
-            f"- Use a cycling profile that holds {profile_sentence}; "
-            f"repeat this profile {self.thermocycling_cycles} times.\n"
-            f"- Denature/inactivate proteins by holding {denaturation_sentence}.\n"
-            f"- Hold at {self.hold_temperature}°C until samples are collected.\n"
-        )
+        for step in self.thermocycling_profile:
+            time_value = step['hold_time_minutes']
+            time_text = f"{time_value} min" if isinstance(time_value, (int, float)) else str(time_value)
+            lines.append(f"| {step['step']} | {step['temperature']} C | {time_text} | {step['cycles']} |")
+        lines.append("")
+        return lines
 
     def render_markdown(self) -> str:
         """Render a complete manual protocol in Markdown format."""
@@ -1509,7 +1528,7 @@ class ManualAssembly(BaseAssembly):
             self.process_assemblies()
 
         lines = [
-            "# Golden Gate Manual Assembly Protocol",
+            "# Manual Golden Gate Assembly Protocol",
             "",
             "## Overview",
             "Golden Gate assembly is a one-pot DNA cloning method that uses a Type IIS restriction enzyme, "
@@ -1521,64 +1540,39 @@ class ManualAssembly(BaseAssembly):
             "ligation temperatures. Repetition of these cycles enriches for the correctly assembled composite "
             "plasmid, after which the enzymes are heat-inactivated and the reaction is held at 4 °C until collection.",
             "",
-            "## Inputs",
-            f"- Number of target products: {len(self.reaction_records)}",
+            "## Reaction Setup",
+            "",
+            f"- Total reaction volume: {self._fmt_volume(self.volume_total_reaction)} uL",
+            f"- DNA input volume: {self._fmt_volume(self.volume_part)} uL per backbone or part",
+            f"- Assemblies: {len(self.reaction_records)}",
         ]
-        for record in self.reaction_records:
-            lines.append(f"- `{record.product_name}` ({record.product_uri})")
-
-        lines.extend([
-            "",
-            "## Reaction summary",
-            "| Product | Backbone | Parts | Restriction Enzyme | # DNA Components | DNA each (µL) | Enzyme (µL) | Ligase (µL) | Buffer (µL) | Water (µL) | Total (µL) |",
-            "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
-        ])
-
-        for record in self.reaction_records:
-            lines.append(
-                f"| {record.product_name} | {record.backbone_name} | {', '.join(record.part_names)} | "
-                f"{record.restriction_enzyme_name} | {record.number_of_dna_components} | "
-                f"{self._fmt_volume(self.volume_part)} | {self._fmt_volume(self.volume_restriction_enzyme)} | "
-                f"{self._fmt_volume(self.volume_t4_dna_ligase)} | {self._fmt_volume(self.volume_t4_dna_ligase_buffer)} | "
-                f"{self._fmt_volume(record.water_volume)} | {self._fmt_volume(record.total_reaction_volume)} |"
-            )
-
-        lines.append("")
-        lines.append("## Per-reaction instructions")
         lines.append("")
 
-        for record in self.reaction_records:
-            lines.append(f"### Product: {record.product_name}")
-            lines.append(f"URI: {record.product_uri}")
-            lines.append("")
-            lines.append(f"1. Label one tube as `{record.product_name}`.")
-            lines.append(f"2. Add {self._fmt_volume(record.water_volume)} µL nuclease-free water.")
-            lines.append(f"3. Add {self._fmt_volume(self.volume_t4_dna_ligase_buffer)} µL 10X T4 DNA Ligase Buffer.")
-            lines.append(f"4. Add {self._fmt_volume(self.volume_t4_dna_ligase)} µL T4 DNA Ligase.")
-            lines.append(
-                f"5. Add {self._fmt_volume(self.volume_restriction_enzyme)} µL "
-                f"{record.restriction_enzyme_name} (URI: {record.restriction_enzyme_uri})."
+        for index, record in enumerate(self.reaction_records, start=1):
+            lines.extend(
+                [
+                    f"## Assembly {index}: {record.product_name}",
+                    "",
+                    "| Reagent | Volume (uL) |",
+                    "| --- | ---: |",
+                ]
             )
-            lines.append(
-                f"6. Add {self._fmt_volume(self.volume_part)} µL backbone "
-                f"`{record.backbone_name}` (URI: {record.backbone_uri})."
-            )
-
-            step_counter = 7
-            for part_name, part_uri in zip(record.part_names, record.part_uris):
+            for reagent in record.reagent_additions:
                 lines.append(
-                    f"{step_counter}. Add {self._fmt_volume(self.volume_part)} µL part "
-                    f"`{part_name}` (URI: {part_uri})."
+                    f"| {self._markdown_link(reagent['name'], reagent.get('uri'))} | {reagent['volume_uL']} |"
                 )
-                step_counter += 1
+            lines.extend(
+                [
+                    "",
+                    "1. Add reagents to a PCR tube or thermocycler plate well in the order listed.",
+                    "2. Mix gently by pipetting, then briefly spin down.",
+                    "3. Run the thermocycler program below.",
+                    "",
+                ]
+            )
 
-            lines.append(f"{step_counter}. Mix gently by pipetting. Do not vortex unless explicitly intended.")
-            lines.append(f"{step_counter + 1}. Briefly spin down if appropriate.")
-            lines.append("")
-
-        lines.append(self._render_thermocycling_section().rstrip())
+        lines.extend(self._render_thermocycling_section())
         lines.extend([
-            "",
             "## Notes",
             "- Thermocylcer iterations can be increased to improve the reaction efficiency.",
             "- Assumes all DNA parts are available at suitable concentrations and added at equal molarity. Suggested molarities are 20 fmol/µL for parts and 10 fmol/µL for backbones.",

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -1515,10 +1515,18 @@ class ManualAssembly(BaseAssembly):
             "| Step | Temperature | Time | Cycles |",
             "| --- | --- | --- | ---: |",
         ]
-        for step in self.thermocycling_profile:
+        total_steps = len(self.thermocycling_profile)
+        for index, step in enumerate(self.thermocycling_profile, start=1):
             time_value = step['hold_time_minutes']
             time_text = f"{time_value} min" if isinstance(time_value, (int, float)) else str(time_value)
-            lines.append(f"| {step['step']} | {step['temperature']} C | {time_text} | {step['cycles']} |")
+            step_name = step.get('step') or f"Step {index}"
+            if 'cycles' in step:
+                cycles = step['cycles']
+            elif total_steps >= 2 and index <= 2:
+                cycles = self.thermocycling_cycles
+            else:
+                cycles = 1
+            lines.append(f"| {step_name} | {step['temperature']} C | {time_text} | {cycles} |")
         lines.append("")
         return lines
 

--- a/src/pudu/plating.py
+++ b/src/pudu/plating.py
@@ -1,4 +1,5 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, List
+from dataclasses import dataclass
 from pudu import colors, SmartPipette
 from opentrons import protocol_api
 
@@ -402,3 +403,88 @@ class Plating():
         protocol.comment("\n=== Plating protocol complete ===")
         protocol.comment(f"Plated {self.number_constructs} constructs with {self.replicates} replicates")
         protocol.comment(f"Created a total of {self.total_colonies} colonies")
+
+
+@dataclass
+class ManualPlatingRecord:
+    source_well: str
+    construct_name: str
+
+
+class ManualPlating:
+    """Manual counterpart of automated plating protocol."""
+
+    def __init__(self,
+                 plating_data: Optional[Dict] = None,
+                 bacterium_locations: Optional[Dict] = None,
+                 volume_bacteria_transfer: float = 2,
+                 volume_colony: float = 4,
+                 volume_lb_transfer: float = 18,
+                 replicates: int = 1,
+                 number_dilutions: int = 2):
+        if plating_data is not None and bacterium_locations is None:
+            bacterium_locations = plating_data.get("bacterium_locations")
+        if not isinstance(bacterium_locations, dict) or not bacterium_locations:
+            raise ValueError("bacterium_locations must be a non-empty dictionary")
+
+        self.bacterium_locations = bacterium_locations
+        self.volume_bacteria_transfer = volume_bacteria_transfer
+        self.volume_colony = volume_colony
+        self.volume_lb_transfer = volume_lb_transfer
+        self.replicates = replicates
+        self.number_dilutions = number_dilutions
+        self.records: List[ManualPlatingRecord] = []
+
+    def process_bacterium_locations(self):
+        self.records = [
+            ManualPlatingRecord(source_well=well, construct_name=str(name))
+            for well, name in self.bacterium_locations.items()
+        ]
+        return self.records
+
+    def render_markdown(self) -> str:
+        if not self.records:
+            self.process_bacterium_locations()
+
+        lines = [
+            "# Manual Plating Protocol",
+            "",
+            "## Overview",
+            "This protocol describes manual dilution and plating of transformed bacteria from thermocycler wells.",
+            "",
+            "## Setup",
+            f"- Source cultures: {len(self.records)}",
+            f"- Dilutions per construct: {self.number_dilutions}",
+            f"- Replicates per dilution: {self.replicates}",
+            f"- Bacteria transfer volume: {self.volume_bacteria_transfer} uL",
+            f"- LB transfer volume: {self.volume_lb_transfer} uL",
+            f"- Plating volume: {self.volume_colony} uL",
+            "",
+            "## Source Cultures",
+            "",
+            "| Thermocycler well | Construct |",
+            "| --- | --- |",
+        ]
+        for record in self.records:
+            lines.append(f"| {record.source_well} | {record.construct_name} |")
+
+        lines.extend([
+            "",
+            "## Manual Steps",
+            "1. Label dilution tubes/plate wells for each construct and each dilution.",
+            f"2. For each dilution well, pre-load {self.volume_lb_transfer} uL LB medium.",
+            f"3. Add {self.volume_bacteria_transfer} uL bacteria from each source well into dilution 1 and mix.",
+            "4. If a second dilution is required, transfer from dilution 1 into dilution 2 and mix.",
+            f"5. Spot or spread {self.volume_colony} uL from each dilution onto selective agar.",
+            "6. Incubate plates under strain-appropriate conditions until colonies are visible.",
+            "",
+            "## Notes",
+            "- Use fresh sterile tips between constructs and dilution steps.",
+            "- Keep mapping between source wells and plated positions for colony tracking.",
+            "",
+        ])
+        return "\n".join(lines)
+
+    def write_markdown(self, output_path: str):
+        with open(output_path, "w", encoding="utf-8") as handle:
+            handle.write(self.render_markdown())

--- a/src/pudu/transformation.py
+++ b/src/pudu/transformation.py
@@ -1,6 +1,7 @@
 from opentrons import protocol_api
 from typing import List, Dict, Optional
 from pudu.utils import colors
+from dataclasses import dataclass
 
 
 class Transformation():
@@ -572,6 +573,7 @@ class HeatShockTransformation(Transformation):
         print('Genetically modified organisms in thermocycler')
         print(self.dict_of_parts_in_thermocycler)
 
+
     def _validate_protocol(self, protocol, labware):
         """
         Validate protocol requirements and compute all derived counts used throughout run().
@@ -943,4 +945,126 @@ class HeatShockTransformation(Transformation):
                 self.dict_of_parts_in_thermocycler[well_name].append(media_name)
 
             well_index += wells_to_fill
+
+
+@dataclass
+class ManualTransformationRecord:
+    strain_uri: str
+    strain_name: str
+    chassis_uri: str
+    chassis_name: str
+    plasmid_uris: List[str]
+    plasmid_names: List[str]
+
+
+class ManualTransformation:
+    """Manual counterpart of automated transformation protocol."""
+
+    def __init__(self,
+                 transformation_data: Optional[List[Dict]] = None,
+                 transfer_volume_dna: float = 2,
+                 transfer_volume_competent_cell: float = 20,
+                 transfer_volume_recovery_media: float = 60,
+                 replicates: int = 2,
+                 cold_incubation1: Optional[Dict] = None,
+                 heat_shock: Optional[Dict] = None,
+                 cold_incubation2: Optional[Dict] = None,
+                 recovery_incubation: Optional[Dict] = None):
+        if not isinstance(transformation_data, list) or not transformation_data:
+            raise ValueError("transformation_data must be a non-empty list of transformation dictionaries")
+        self.transformation_data = transformation_data
+        self.transfer_volume_dna = transfer_volume_dna
+        self.transfer_volume_competent_cell = transfer_volume_competent_cell
+        self.transfer_volume_recovery_media = transfer_volume_recovery_media
+        self.replicates = replicates
+        self.cold_incubation1 = cold_incubation1 or {'temperature': 4, 'hold_time_minutes': 30}
+        self.heat_shock = heat_shock or {'temperature': 42, 'hold_time_minutes': 1}
+        self.cold_incubation2 = cold_incubation2 or {'temperature': 4, 'hold_time_minutes': 2}
+        self.recovery_incubation = recovery_incubation or {'temperature': 37, 'hold_time_minutes': 60}
+        self.records: List[ManualTransformationRecord] = []
+
+    def _extract_name_from_uri(self, uri: str) -> str:
+        if not isinstance(uri, str):
+            return str(uri)
+        parts = [segment for segment in uri.rstrip("/").split("/") if segment]
+        if len(parts) >= 2 and parts[-1].isdigit():
+            return parts[-2]
+        return parts[-1] if parts else "Unknown"
+
+    def _validate_entry(self, transformation: Dict, index: int):
+        required = {"Strain", "Chassis", "Plasmids"}
+        missing = sorted(required - set(transformation))
+        if missing:
+            raise ValueError(f"Transformation {index} is missing required field(s): {', '.join(missing)}")
+        if not isinstance(transformation["Plasmids"], list) or not transformation["Plasmids"]:
+            raise ValueError(f"Transformation {index} must include at least one plasmid in Plasmids")
+
+    def process_transformations(self):
+        self.records = []
+        for idx, entry in enumerate(self.transformation_data, start=1):
+            self._validate_entry(entry, idx)
+            self.records.append(
+                ManualTransformationRecord(
+                    strain_uri=entry["Strain"],
+                    strain_name=self._extract_name_from_uri(entry["Strain"]),
+                    chassis_uri=entry["Chassis"],
+                    chassis_name=self._extract_name_from_uri(entry["Chassis"]),
+                    plasmid_uris=entry["Plasmids"],
+                    plasmid_names=[self._extract_name_from_uri(p) for p in entry["Plasmids"]],
+                )
+            )
+        return self.records
+
+    def render_markdown(self) -> str:
+        if not self.records:
+            self.process_transformations()
+        lines = [
+            "# Manual Heat Shock Transformation Protocol",
+            "",
+            "## Overview",
+            "This protocol describes manual bacterial heat-shock transformation for SBOL-defined strains and plasmids.",
+            "",
+            "## Reaction Setup",
+            f"- Competent cells per reaction: {self.transfer_volume_competent_cell} uL",
+            f"- DNA per reaction: {self.transfer_volume_dna} uL",
+            f"- Recovery media per reaction: {self.transfer_volume_recovery_media} uL",
+            f"- Replicates per transformation: {self.replicates}",
+            f"- Transformations: {len(self.records)}",
+            "",
+        ]
+        for index, record in enumerate(self.records, start=1):
+            lines.extend([
+                f"## Transformation {index}: {record.strain_name}",
+                "",
+                f"- Strain: `{record.strain_name}` ({record.strain_uri})",
+                f"- Chassis: `{record.chassis_name}` ({record.chassis_uri})",
+                f"- Plasmids: {', '.join(f'`{p}`' for p in record.plasmid_names)}",
+                "",
+                "1. Label tube(s) for this transformation.",
+                f"2. Add {self.transfer_volume_competent_cell} uL competent cells.",
+                f"3. Add {self.transfer_volume_dna} uL DNA plasmid mix.",
+                "4. Mix gently by pipetting and keep on ice.",
+                "",
+            ])
+        lines.extend([
+            "## Thermocycler/Incubation Program",
+            "",
+            "| Step | Temperature | Time |",
+            "| --- | --- | --- |",
+            f"| Cold incubation 1 | {self.cold_incubation1['temperature']} C | {self.cold_incubation1['hold_time_minutes']} min |",
+            f"| Heat shock | {self.heat_shock['temperature']} C | {self.heat_shock['hold_time_minutes']} min |",
+            f"| Cold incubation 2 | {self.cold_incubation2['temperature']} C | {self.cold_incubation2['hold_time_minutes']} min |",
+            f"| Recovery | {self.recovery_incubation['temperature']} C | {self.recovery_incubation['hold_time_minutes']} min |",
+            "",
+            "## Post-heat-shock",
+            f"1. Add {self.transfer_volume_recovery_media} uL recovery media.",
+            "2. Incubate according to recovery step.",
+            "3. Plate transformed cells on selective agar.",
+            "",
+        ])
+        return "\n".join(lines)
+
+    def write_markdown(self, output_path: str):
+        with open(output_path, "w", encoding="utf-8") as handle:
+            handle.write(self.render_markdown())
 

--- a/tests/test_manual_assembly.py
+++ b/tests/test_manual_assembly.py
@@ -48,13 +48,12 @@ class TestManualAssembly(unittest.TestCase):
         assembly = ManualAssembly(assemblies=self.assemblies)
         markdown = assembly.render_markdown()
 
-        self.assertIn("# Golden Gate Manual Assembly Protocol", markdown)
-        self.assertIn("## Reaction summary", markdown)
-        self.assertIn("DNA each (µL)", markdown)
-        self.assertIn("### Product: composite_1", markdown)
-        self.assertIn("Add 2 µL part `J23101`", markdown)
-        self.assertIn("## Thermocycling", markdown)
-        self.assertIn("repeat this profile 75 times", markdown)
+        self.assertIn("# Manual Golden Gate Assembly Protocol", markdown)
+        self.assertIn("## Reaction Setup", markdown)
+        self.assertIn("## Assembly 1: composite_1", markdown)
+        self.assertIn("| [J23101](https://sbolcanvas.org/J23101/1) | 2 |", markdown)
+        self.assertIn("## Thermocycler Program", markdown)
+        self.assertIn("| Digest | 37 C | 2 min | 25 |", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/test_manual_assembly.py
+++ b/tests/test_manual_assembly.py
@@ -55,6 +55,26 @@ class TestManualAssembly(unittest.TestCase):
         self.assertIn("## Thermocycler Program", markdown)
         self.assertIn("| Digest | 37 C | 2 min | 25 |", markdown)
 
+    def test_markdown_rendering_supports_legacy_thermocycling_profile(self):
+        legacy_profile = [
+            {"temperature": 37, "hold_time_minutes": 2},
+            {"temperature": 16, "hold_time_minutes": 5},
+            {"temperature": 80, "hold_time_minutes": 10},
+            {"temperature": 4, "hold_time_minutes": "indefinite"},
+        ]
+        assembly = ManualAssembly(
+            assemblies=self.assemblies,
+            thermocycling_profile=legacy_profile,
+            thermocycling_cycles=30,
+        )
+
+        markdown = assembly.render_markdown()
+
+        self.assertIn("| Step 1 | 37 C | 2 min | 30 |", markdown)
+        self.assertIn("| Step 2 | 16 C | 5 min | 30 |", markdown)
+        self.assertIn("| Step 3 | 80 C | 10 min | 1 |", markdown)
+        self.assertIn("| Step 4 | 4 C | indefinite | 1 |", markdown)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- updated `ManualAssembly` markdown rendering to output per-assembly reagent tables and a thermocycler-program table matching the requested human-instructions format
- improved name/URI handling to support both URI strings and SBOL-style dictionaries
- added markdown link rendering for reagents with URIs in per-assembly tables
- aligned default thermocycler section to digest/ligate/final-digest/inactivation/hold steps
- updated `tests/test_manual_assembly.py` assertions for the new protocol structure

## Details
- `src/pudu/assembly.py`
  - switched protocol title and structure to:
    - Overview
    - Reaction Setup
    - Assembly N reagent tables
    - Thermocycler Program
    - Notes
  - added helper methods:
    - `_extract_uri`
    - `_markdown_link`
  - expanded `_extract_name_from_uri` to parse dict entries and fall back safely
  - adjusted reagent-addition generation to support linked backbone/parts rows
- `tests/test_manual_assembly.py`
  - replaced old section/content assertions with checks for the new table-based layout and thermocycler program rows

## Validation
- static review only (no test execution performed in this environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3db55f3c88323b84cbd855aa3af2c)