### PR TITLE
Refactor plating protocol: single LB tip, shared dilution wells, dilu…

### DIFF
--- a/src/pudu/plating.py
+++ b/src/pudu/plating.py
@@ -15,7 +15,7 @@ class Plating():
                  volume_total_reaction: float = 20,
                  volume_bacteria_transfer: float = 2,
                  volume_colony: float = 4,
-                 volume_lb_transfer: float = 18,
+                 dilution_factor: float = 10,
                  volume_lb: float = 10000,
                  replicates: int = 1,
                  number_dilutions: int = 2,
@@ -56,7 +56,7 @@ class Plating():
             'volume_total_reaction': volume_total_reaction,
             'volume_bacteria_transfer': volume_bacteria_transfer,
             'volume_colony': volume_colony,
-            'volume_lb_transfer': volume_lb_transfer,
+            'dilution_factor': dilution_factor,
             'volume_lb': volume_lb,
             'replicates': replicates,
             'number_dilutions': number_dilutions,
@@ -97,7 +97,8 @@ class Plating():
         self.volume_total_reaction = self._merged_params['volume_total_reaction']
         self.volume_bacteria_transfer = self._merged_params['volume_bacteria_transfer']
         self.volume_colony = self._merged_params['volume_colony']
-        self.volume_lb_transfer = self._merged_params['volume_lb_transfer']
+        self.dilution_factor = self._merged_params['dilution_factor']
+        self.volume_lb_transfer = self.volume_bacteria_transfer * (self.dilution_factor - 1)
         self.volume_lb = self._merged_params['volume_lb']
         self.replicates = self._merged_params['replicates']
         self.number_dilutions = self._merged_params['number_dilutions']
@@ -137,6 +138,21 @@ class Plating():
         if self.number_dilutions > 2:
             raise ValueError("Protocol currently supports a max of 2 dilutions")
 
+        # Each dilution well must hold enough volume for all agar platings plus seeding the next
+        # dilution step. Check before any labware is loaded so errors surface early.
+        volume_dilution_well = self.volume_bacteria_transfer * self.dilution_factor
+        volumes_needed = self.volume_colony * self.replicates + (
+            self.volume_bacteria_transfer if self.number_dilutions > 1 else 0
+        )
+        if volumes_needed > volume_dilution_well:
+            raise ValueError(
+                f"Dilution well volume ({volume_dilution_well:.1f} µL) is insufficient: "
+                f"plating {self.replicates} replicates × {self.volume_colony} µL"
+                + (f" + {self.volume_bacteria_transfer} µL to seed next dilution" if self.number_dilutions > 1 else "")
+                + f" requires {volumes_needed:.1f} µL. "
+                f"Increase dilution_factor or reduce replicates/volume_colony."
+            )
+
     def _merge_params(self, plating_data: Optional[Dict], json_params: Optional[Dict], kwargs_params: Dict) -> Dict:
         """
         Merge parameters with precedence: defaults <- plating_data <- json_params <- kwargs
@@ -154,7 +170,7 @@ class Plating():
             'volume_total_reaction': 20,
             'volume_bacteria_transfer': 2,
             'volume_colony': 4,
-            'volume_lb_transfer': 18,
+            'dilution_factor': 10,
             'volume_lb': 10000,
             'replicates': 1,
             'number_dilutions': 2,
@@ -226,37 +242,46 @@ class Plating():
                 f"Valid parameters are: {set(valid_params.keys())}"
             )
 
-    def calculate_plate_layout(self,protocol, plate1, plate2=None):
+    def calculate_plate_layout(self, protocol, plate1, plate2=None, wells_per_dilution=None):
         """
-        Calculate the layout for colonies on plates with dynamic buffer between dilutions
-        Returns: dict with plate assignments and well positions
-        """
-        colonies_per_dilution = self.number_constructs * self.replicates
+        Calculate the layout for wells on a plate with dynamic expansion across two plates.
 
-        layout =  {
-            'dilution_1': {'plate': 1, 'wells':[]},
-            'dilution_2': {'plate': 1, 'wells':[]} if self.number_dilutions ==2 else None
+        Args:
+            protocol: Protocol context (used for comments)
+            plate1: Primary labware object
+            plate2: Optional secondary labware object, required when wells_per_dilution > 48
+            wells_per_dilution: Number of wells needed per dilution step. Defaults to
+                number_constructs * replicates (original behaviour). Pass
+                number_constructs for dilution plates and number_constructs * replicates
+                for agar plates.
+
+        Returns:
+            dict with plate assignments and well positions keyed by 'dilution_1' / 'dilution_2'
+        """
+        if wells_per_dilution is None:
+            wells_per_dilution = self.number_constructs * self.replicates
+
+        layout = {
+            'dilution_1': {'plate': 1, 'wells': []},
+            'dilution_2': {'plate': 1, 'wells': []} if self.number_dilutions == 2 else None
         }
 
-        #Check if we need two plates
-        if self.number_dilutions ==2 and colonies_per_dilution > 48:
+        if self.number_dilutions == 2 and wells_per_dilution > 48:
             if plate2 is None:
                 raise ValueError("Two plates required but plate2 not provided")
-            #Each Dilution gets its own plate
-            layout['dilution_1']['wells'] = plate1.wells()[:colonies_per_dilution]
+            # Each dilution step gets its own plate
+            layout['dilution_1']['wells'] = plate1.wells()[:wells_per_dilution]
             layout['dilution_2']['plate'] = 2
-            layout['dilution_2']['wells'] = plate2.wells()[:colonies_per_dilution]
-            protocol.comment(f"Using 2 plates: {colonies_per_dilution} colonies per dilution exceeds single plate capacity")
-        elif self.number_dilutions ==2 and colonies_per_dilution <= 48:
-            #Both Dilutions Fit On One Plate
-            first_half = plate1.wells()[:colonies_per_dilution]
-            second_half = plate1.wells()[48:48+colonies_per_dilution]
-            layout['dilution_1']['wells'] = first_half
-            layout['dilution_2']['wells'] = second_half
-            protocol.comment(f"Using only one {plate1}: {colonies_per_dilution} colonies on each half")
+            layout['dilution_2']['wells'] = plate2.wells()[:wells_per_dilution]
+            protocol.comment(f"Using 2 plates: {wells_per_dilution} wells per dilution exceeds single-plate half capacity")
+        elif self.number_dilutions == 2 and wells_per_dilution <= 48:
+            # Both dilution steps fit on one plate (each in one half)
+            layout['dilution_1']['wells'] = plate1.wells()[:wells_per_dilution]
+            layout['dilution_2']['wells'] = plate1.wells()[48:48 + wells_per_dilution]
+            protocol.comment(f"Using one plate: {wells_per_dilution} wells per dilution fits in each half")
         else:
-            #Single dilution
-            layout['dilution_1']['wells'] = plate1.wells()[:colonies_per_dilution]
+            # Single dilution step
+            layout['dilution_1']['wells'] = plate1.wells()[:wells_per_dilution]
         return layout
 
     def run(self, protocol: protocol_api.ProtocolContext):
@@ -296,21 +321,35 @@ class Plating():
             well = thermocycler_plate[well_position]
             well.load_liquid(liquid=liquid_bacteria, volume=self.volume_total_reaction)
 
-        # Load the dilution plates and Calculate the layout of the plates
+        # Load dilution plates — one well per construct per dilution step
         dilution_plate1 = protocol.load_labware(self.dilution_plate, self.dilution_plate_position1)
-        if self.total_colonies <= len(dilution_plate1.wells()):
-            dilution_layout = self.calculate_plate_layout(protocol, dilution_plate1)
-        else:
-            dilution_plate2 = protocol.load_labware(self.dilution_plate, self.dilution_plate_position2)
-            dilution_layout = self.calculate_plate_layout(protocol, dilution_plate1, dilution_plate2)
 
-        #Load the Agar plates and Calculate the layout of the plates
-        agar_plate1 = protocol.load_labware(self.agar_plate, self.agar_plate_position1)
-        if self.total_colonies <= len(agar_plate1.wells()):
-            agar_layout = self.calculate_plate_layout(protocol, agar_plate1)
+        # Validate that the dilution well can physically hold the full dilution volume
+        dilution_well_max = dilution_plate1.wells()[0].max_volume
+        volume_dilution_well = self.volume_bacteria_transfer * self.dilution_factor
+        if volume_dilution_well > dilution_well_max:
+            raise ValueError(
+                f"Dilution factor {self.dilution_factor} with {self.volume_bacteria_transfer} µL bacteria transfer "
+                f"requires {volume_dilution_well:.1f} µL per well, but '{self.dilution_plate}' wells hold "
+                f"only {dilution_well_max:.1f} µL. Reduce dilution_factor or switch to a larger dilution plate."
+            )
+        if self.number_constructs * self.number_dilutions > len(dilution_plate1.wells()):
+            dilution_plate2 = protocol.load_labware(self.dilution_plate, self.dilution_plate_position2)
+            dilution_layout = self.calculate_plate_layout(protocol, dilution_plate1, dilution_plate2,
+                                                          wells_per_dilution=self.number_constructs)
         else:
+            dilution_layout = self.calculate_plate_layout(protocol, dilution_plate1,
+                                                          wells_per_dilution=self.number_constructs)
+
+        # Load agar plates — one well per construct per replicate per dilution step
+        agar_plate1 = protocol.load_labware(self.agar_plate, self.agar_plate_position1)
+        if self.total_colonies > len(agar_plate1.wells()):
             agar_plate2 = protocol.load_labware(self.agar_plate, self.agar_plate_position2)
-            agar_layout = self.calculate_plate_layout(protocol, agar_plate1, agar_plate2)
+            agar_layout = self.calculate_plate_layout(protocol, agar_plate1, agar_plate2,
+                                                      wells_per_dilution=self.number_constructs * self.replicates)
+        else:
+            agar_layout = self.calculate_plate_layout(protocol, agar_plate1,
+                                                      wells_per_dilution=self.number_constructs * self.replicates)
 
 
         thermocycler.set_block_temperature(4)
@@ -322,9 +361,10 @@ class Plating():
         all_dilution_wells = dilution_layout['dilution_1']['wells'][:]
         if self.number_dilutions == 2 and dilution_layout['dilution_2']:
             all_dilution_wells.extend(dilution_layout['dilution_2']['wells'])
-        # Distribute LB efficiently using built-in distribute method
-        # Process in chunks of 8 wells to update aspiration height
+        # Distribute LB using a single tip for the entire step
+        # Process in chunks of 8 wells to update aspiration height as the tube empties
         chunk_size = 8
+        large_pipette.pick_up_tip()
         for i in range(0, len(all_dilution_wells), chunk_size):
             chunk_wells = all_dilution_wells[i:i + chunk_size]
 
@@ -332,68 +372,62 @@ class Plating():
             aspiration_location = smart_pipette.get_aspiration_location(lb_tube)
             protocol.comment(f"Distributing to wells {i + 1}-{min(i + chunk_size, len(all_dilution_wells))}")
 
-            # Use built-in distribute method with updated aspiration location
+            # Distribute without picking up a new tip each chunk
             large_pipette.distribute(
                 volume=self.volume_lb_transfer,
                 source=aspiration_location,
                 dest=chunk_wells,
-                disposal_volume=4,  # For accuracy
-                new_tip='once'  # Use one tip for the chunk
+                disposal_volume=4,
+                new_tip='never'
             )
 
             # Load liquid tracking for dilution wells
             for well in chunk_wells:
                 well.load_liquid(liquid=liquid_broth, volume=self.volume_lb_transfer)
+        large_pipette.drop_tip()
 
         #Transfer bacteria to first dilution and process
         protocol.comment("\n=== Step 2: Transferring bacteria and plating ===")
 
-        well_index = 0
-        for construct_position, construct_names in self.bacterium_locations.items():
+        for construct_idx, (construct_position, construct_names) in enumerate(self.bacterium_locations.items()):
+            source_well = thermocycler_plate[construct_position]
+            dilution1_well = dilution_layout['dilution_1']['wells'][construct_idx]
+
+            protocol.comment(f"\nProcessing construct {construct_idx + 1}: {construct_names}")
+
+            # === Tip 1: set up dilutions + plate all dilution-1 replicates ===
+            small_pipette.pick_up_tip()
+
+            # Transfer bacteria → dilution1, mix
+            small_pipette.aspirate(self.volume_bacteria_transfer, source_well, rate=self.aspiration_rate)
+            small_pipette.dispense(self.volume_bacteria_transfer, dilution1_well, rate=self.dispense_rate)
+            small_pipette.mix(repetitions=5, volume=19, location=dilution1_well)
+
+            if self.number_dilutions == 2:
+                dilution2_well = dilution_layout['dilution_2']['wells'][construct_idx]
+                # Seed dilution2 first (before any agar aspirations from dilution1)
+                small_pipette.aspirate(self.volume_bacteria_transfer, dilution1_well, rate=self.aspiration_rate)
+                small_pipette.dispense(self.volume_bacteria_transfer, dilution2_well, rate=self.dispense_rate)
+                small_pipette.mix(repetitions=5, volume=19, location=dilution2_well)
+
+            # Plate all dilution-1 replicates
             for replicate in range(self.replicates):
-                # Get source and destination wells
-                source_well = thermocycler_plate[construct_position]
-                dilution1_well = dilution_layout['dilution_1']['wells'][well_index]
-                agar1_well = agar_layout['dilution_1']['wells'][well_index]
-
-                protocol.comment(f"\nProcessing {construct_names[0]} replicate {replicate + 1}")
-
-                # Pick up tip once for entire workflow per well
-                small_pipette.pick_up_tip()
-
-                # Transfer bacteria to dilution plate 1
-                small_pipette.aspirate(self.volume_bacteria_transfer, source_well, rate=self.aspiration_rate)
-                small_pipette.dispense(self.volume_bacteria_transfer, dilution1_well, rate=self.dispense_rate)
-
-                # Mix in dilution plate 1 (15µL mixing volume)
-                small_pipette.mix(repetitions=5, volume=19, location=dilution1_well)
-
-                # Plate on agar 1
+                agar1_well = agar_layout['dilution_1']['wells'][construct_idx * self.replicates + replicate]
                 small_pipette.aspirate(self.volume_colony, dilution1_well, rate=self.aspiration_rate)
                 small_pipette.dispense(self.volume_colony, agar1_well.top(-8), rate=self.dispense_rate)
                 small_pipette.blow_out()
 
-                # If we have a second dilution, continue with same tip
-                if self.number_dilutions == 2:
-                    dilution2_well = dilution_layout['dilution_2']['wells'][well_index]
-                    agar2_well = agar_layout['dilution_2']['wells'][well_index]
+            small_pipette.drop_tip()
 
-                    # Transfer from dilution 1 to dilution 2
-                    small_pipette.aspirate(self.volume_bacteria_transfer, dilution1_well, rate=self.aspiration_rate)
-                    small_pipette.dispense(self.volume_bacteria_transfer, dilution2_well, rate=self.dispense_rate)
-
-                    # Mix in dilution plate 2
-                    small_pipette.mix(repetitions=5, volume=19, location=dilution2_well)
-
-                    # Plate on agar 2
+            # === Tip 2: plate all dilution-2 replicates with a clean tip ===
+            if self.number_dilutions == 2:
+                small_pipette.pick_up_tip()
+                for replicate in range(self.replicates):
+                    agar2_well = agar_layout['dilution_2']['wells'][construct_idx * self.replicates + replicate]
                     small_pipette.aspirate(self.volume_colony, dilution2_well, rate=self.aspiration_rate)
                     small_pipette.dispense(self.volume_colony, agar2_well.top(-8), rate=self.dispense_rate)
                     small_pipette.blow_out()
-
-                # Drop tip after completing all transfers for this well
                 small_pipette.drop_tip()
-
-                well_index += 1
 
         # Close thermocycler lid
         # thermocycler.close_lid()

--- a/src/pudu/plating.py
+++ b/src/pudu/plating.py
@@ -99,6 +99,10 @@ class Plating():
         self.volume_colony = self._merged_params['volume_colony']
         self.dilution_factor = self._merged_params['dilution_factor']
         self.volume_lb_transfer = self.volume_bacteria_transfer * (self.dilution_factor - 1)
+        # Mix volume is capped 1 µL below the total dilution well volume so the pipette
+        # never tries to aspirate more than is physically present. Also bounded by the
+        # p20 maximum (19 µL).
+        self.mix_volume = min(19, self.volume_lb_transfer + self.volume_bacteria_transfer - 1)
         self.volume_lb = self._merged_params['volume_lb']
         self.replicates = self._merged_params['replicates']
         self.number_dilutions = self._merged_params['number_dilutions']
@@ -401,14 +405,14 @@ class Plating():
             # Transfer bacteria → dilution1, mix
             small_pipette.aspirate(self.volume_bacteria_transfer, source_well, rate=self.aspiration_rate)
             small_pipette.dispense(self.volume_bacteria_transfer, dilution1_well, rate=self.dispense_rate)
-            small_pipette.mix(repetitions=5, volume=19, location=dilution1_well)
+            small_pipette.mix(repetitions=5, volume=self.mix_volume, location=dilution1_well)
 
             if self.number_dilutions == 2:
                 dilution2_well = dilution_layout['dilution_2']['wells'][construct_idx]
                 # Seed dilution2 first (before any agar aspirations from dilution1)
                 small_pipette.aspirate(self.volume_bacteria_transfer, dilution1_well, rate=self.aspiration_rate)
                 small_pipette.dispense(self.volume_bacteria_transfer, dilution2_well, rate=self.dispense_rate)
-                small_pipette.mix(repetitions=5, volume=19, location=dilution2_well)
+                small_pipette.mix(repetitions=5, volume=self.mix_volume, location=dilution2_well)
 
             # Plate all dilution-1 replicates
             for replicate in range(self.replicates):

--- a/tests/test_plating.py
+++ b/tests/test_plating.py
@@ -1,0 +1,323 @@
+"""
+Unit tests for Plating validation logic and parameter handling.
+
+Tests are split into:
+  - TestPlatingInit         : __init__ / basic attribute wiring
+  - TestPlatingValidation   : hard limits (colonies, replicates, dilutions, well volume)
+  - TestDilutionFactor      : dilution_factor parameter and derived volume_lb_transfer
+  - TestMergeParams         : param hierarchy (plating_data → json_params → kwargs)
+  - TestPlateLayout         : calculate_plate_layout single/double plate logic
+"""
+
+import unittest
+from unittest.mock import MagicMock
+from pudu.plating import Plating
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+def make_plating(bacterium_locations=None, **kwargs):
+    """Convenience wrapper — instantiate Plating with a default single construct."""
+    if bacterium_locations is None:
+        bacterium_locations = SINGLE_CONSTRUCT
+    return Plating(bacterium_locations=bacterium_locations, **kwargs)
+
+
+class MockPlate:
+    """Minimal stand-in for a labware plate in calculate_plate_layout."""
+    def __init__(self, num_wells=96):
+        # Plain integers serve as stand-in well objects; calculate_plate_layout only slices them.
+        self._wells = list(range(num_wells))
+
+    def wells(self):
+        return self._wells
+
+
+SINGLE_CONSTRUCT = {'A1': ['DH5alpha', 'plasmid_1']}
+
+THREE_CONSTRUCTS = {
+    'A1': ['DH5alpha', 'plasmid_1'],
+    'B1': ['DH5alpha', 'plasmid_2'],
+    'C1': ['DH5alpha', 'plasmid_3'],
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Init / basic attribute wiring
+# ---------------------------------------------------------------------------
+
+class TestPlatingInit(unittest.TestCase):
+
+    def test_no_bacterium_locations_raises(self):
+        """Omitting bacterium_locations entirely must raise immediately."""
+        with self.assertRaises(ValueError) as ctx:
+            Plating()
+        self.assertIn('Must input', str(ctx.exception))
+
+    def test_valid_minimal_construction(self):
+        """Minimal valid call must succeed."""
+        p = make_plating()
+        self.assertIsNotNone(p)
+
+    def test_number_constructs_computed_from_locations(self):
+        p = make_plating(THREE_CONSTRUCTS)
+        self.assertEqual(p.number_constructs, 3)
+
+    def test_total_colonies_computed(self):
+        """total_colonies == number_constructs × number_dilutions × replicates."""
+        p = make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=2)
+        self.assertEqual(p.total_colonies, 3 * 2 * 2)
+
+    def test_volume_lb_transfer_derived_from_default_factor(self):
+        """Default dilution_factor=10, bacteria=2 → volume_lb_transfer = 2×9 = 18."""
+        p = make_plating()
+        self.assertAlmostEqual(p.volume_lb_transfer, 18.0)
+
+    def test_volume_lb_transfer_updates_with_custom_factor(self):
+        """dilution_factor=5, bacteria=2 → volume_lb_transfer = 2×4 = 8."""
+        p = make_plating(dilution_factor=5)
+        self.assertAlmostEqual(p.volume_lb_transfer, 8.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Hard limit validations (all checked in __init__)
+# ---------------------------------------------------------------------------
+
+class TestPlatingValidation(unittest.TestCase):
+
+    def test_too_many_colonies_raises(self):
+        """total_colonies > max_colonies must raise."""
+        with self.assertRaises(ValueError):
+            make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=2, max_colonies=5)
+        # 3 × 2 × 2 = 12 > 5
+
+    def test_too_many_replicates_raises(self):
+        """replicates > 8 must raise."""
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(replicates=9)
+        self.assertIn('8', str(ctx.exception))
+
+    def test_number_dilutions_above_2_raises(self):
+        """number_dilutions > 2 must raise — only 1 or 2 dilution steps are supported."""
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(number_dilutions=3)
+        self.assertIn('2', str(ctx.exception))
+
+    def test_volume_sufficiency_raises_when_well_too_small(self):
+        """
+        dilution_factor=2, bacteria=2 → well = 4 µL.
+        2 replicates × 4 µL + 2 µL seed = 10 µL > 4 µL → must raise.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(dilution_factor=2, replicates=2, number_dilutions=2)
+        self.assertIn('insufficient', str(ctx.exception))
+
+    def test_volume_sufficiency_passes_at_exact_boundary(self):
+        """
+        Default: factor=10, bacteria=2, colony=4, dilutions=2.
+        4 replicates × 4 µL + 2 µL seed = 18 µL ≤ 20 µL → must not raise.
+        """
+        make_plating(replicates=4, dilution_factor=10, number_dilutions=2)
+
+    def test_volume_sufficiency_raises_one_replicate_above_boundary(self):
+        """
+        5 replicates × 4 µL + 2 µL seed = 22 µL > 20 µL → must raise.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(replicates=5, dilution_factor=10, number_dilutions=2)
+        self.assertIn('insufficient', str(ctx.exception))
+
+    def test_single_dilution_relaxes_volume_constraint(self):
+        """
+        With number_dilutions=1 there is no seed volume to reserve.
+        factor=4, bacteria=2 → well = 8 µL.
+        2 replicates × 4 µL = 8 µL ≤ 8 µL → passes for 1 dilution.
+        The same config would fail with 2 dilutions (8 + 2 = 10 > 8).
+        """
+        with self.assertRaises(ValueError):
+            make_plating(dilution_factor=4, replicates=2, number_dilutions=2)
+
+        # Must not raise with 1 dilution
+        make_plating(dilution_factor=4, replicates=2, number_dilutions=1)
+
+    def test_volume_sufficiency_error_message_is_informative(self):
+        """Error message must mention the well volume, the need, and a suggested fix."""
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(dilution_factor=2, replicates=2, number_dilutions=2)
+        msg = str(ctx.exception)
+        self.assertIn('µL', msg)
+        self.assertIn('dilution_factor', msg)
+
+
+# ---------------------------------------------------------------------------
+# 3. dilution_factor parameter
+# ---------------------------------------------------------------------------
+
+class TestDilutionFactor(unittest.TestCase):
+
+    def test_default_dilution_factor_is_ten(self):
+        p = make_plating()
+        self.assertEqual(p.dilution_factor, 10)
+
+    def test_custom_dilution_factor_stored(self):
+        p = make_plating(dilution_factor=5)
+        self.assertEqual(p.dilution_factor, 5)
+
+    def test_dilution_factor_via_json_params(self):
+        """dilution_factor must be settable via the json_params hierarchy."""
+        p = make_plating(json_params={'dilution_factor': 20})
+        self.assertEqual(p.dilution_factor, 20)
+        self.assertAlmostEqual(p.volume_lb_transfer, 38.0)  # 2 × (20-1) = 38
+
+    def test_volume_lb_transfer_rejected_as_direct_param(self):
+        """
+        volume_lb_transfer is no longer a valid parameter — it is derived.
+        Passing it via json_params must raise an unknown-parameter error.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(json_params={'volume_lb_transfer': 18})
+        self.assertIn('volume_lb_transfer', str(ctx.exception))
+
+    def test_dilution_factor_kwargs_overrides_json_params(self):
+        """A kwarg dilution_factor must take precedence over json_params."""
+        p = make_plating(json_params={'dilution_factor': 5}, dilution_factor=20)
+        self.assertEqual(p.dilution_factor, 20)
+
+    def test_large_dilution_factor_allowed_when_volume_fits(self):
+        """A large factor is fine as long as volumes stay within limits."""
+        # factor=20, bacteria=2 → well=40 µL; 1 replicate × 4 + 2 seed = 6 ≤ 40
+        p = make_plating(dilution_factor=20, replicates=1, number_dilutions=2)
+        self.assertAlmostEqual(p.volume_lb_transfer, 38.0)
+
+
+# ---------------------------------------------------------------------------
+# 4. Parameter merge hierarchy
+# ---------------------------------------------------------------------------
+
+class TestMergeParams(unittest.TestCase):
+
+    def test_bacterium_locations_via_plating_data(self):
+        """plating_data is the primary way to pass bacterium_locations."""
+        p = Plating(plating_data={'bacterium_locations': SINGLE_CONSTRUCT})
+        self.assertEqual(p.bacterium_locations, SINGLE_CONSTRUCT)
+
+    def test_json_params_overrides_plating_data(self):
+        """json_params must take precedence over plating_data for shared keys."""
+        p = Plating(
+            plating_data={'bacterium_locations': SINGLE_CONSTRUCT, 'replicates': 1},
+            json_params={'replicates': 3}
+        )
+        self.assertEqual(p.replicates, 3)
+
+    def test_kwargs_override_json_params(self):
+        """An explicit kwarg must override json_params."""
+        p = make_plating(json_params={'dilution_factor': 5}, dilution_factor=15)
+        self.assertEqual(p.dilution_factor, 15)
+
+    def test_unknown_param_in_json_params_raises(self):
+        """An unrecognised key in json_params must raise a descriptive error."""
+        with self.assertRaises(ValueError) as ctx:
+            make_plating(json_params={'not_a_valid_param': 99})
+        self.assertIn('not_a_valid_param', str(ctx.exception))
+
+    def test_unknown_param_in_plating_data_raises(self):
+        """An unrecognised key in plating_data must also raise."""
+        with self.assertRaises(ValueError) as ctx:
+            Plating(plating_data={
+                'bacterium_locations': SINGLE_CONSTRUCT,
+                'bad_param': 1
+            })
+        self.assertIn('bad_param', str(ctx.exception))
+
+    def test_defaults_used_when_nothing_overrides(self):
+        """Check a sample of defaults are applied when nothing is provided."""
+        p = make_plating()
+        self.assertEqual(p.replicates, 1)
+        self.assertEqual(p.number_dilutions, 2)
+        self.assertEqual(p.dilution_factor, 10)
+        self.assertAlmostEqual(p.volume_colony, 4.0)
+
+
+# ---------------------------------------------------------------------------
+# 5. calculate_plate_layout
+# ---------------------------------------------------------------------------
+
+class TestPlateLayout(unittest.TestCase):
+    """
+    Call calculate_plate_layout directly with MockPlate objects so we can test
+    the slicing and two-plate expansion logic without a full protocol context.
+    """
+
+    def _make_layout(self, plating, wells_per_dilution, plate2=None):
+        plate1 = MockPlate()
+        return plating.calculate_plate_layout(
+            MagicMock(), plate1, plate2, wells_per_dilution=wells_per_dilution
+        ), plate1
+
+    def test_single_dilution_populates_only_dilution_1(self):
+        """number_dilutions=1 → dilution_2 key must be None."""
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=1)
+        layout, plate1 = self._make_layout(p, wells_per_dilution=3)
+        self.assertIsNone(layout['dilution_2'])
+        self.assertEqual(layout['dilution_1']['wells'], plate1.wells()[:3])
+
+    def test_two_dilutions_fit_on_one_plate(self):
+        """
+        3 constructs (≤ 48) → both dilution steps fit in halves of a single plate.
+        dilution_1 occupies wells [0:3], dilution_2 occupies wells [48:51].
+        """
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=2)
+        layout, plate1 = self._make_layout(p, wells_per_dilution=3)
+        self.assertEqual(layout['dilution_1']['plate'], 1)
+        self.assertEqual(layout['dilution_2']['plate'], 1)
+        self.assertEqual(layout['dilution_1']['wells'], plate1.wells()[:3])
+        self.assertEqual(layout['dilution_2']['wells'], plate1.wells()[48:51])
+
+    def test_two_dilutions_overflow_to_two_plates(self):
+        """
+        50 wells per dilution > 48 → each dilution step gets its own plate.
+        """
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=2)
+        plate1 = MockPlate()
+        plate2 = MockPlate()
+        layout = p.calculate_plate_layout(MagicMock(), plate1, plate2, wells_per_dilution=50)
+        self.assertEqual(layout['dilution_1']['plate'], 1)
+        self.assertEqual(layout['dilution_2']['plate'], 2)
+        self.assertEqual(len(layout['dilution_1']['wells']), 50)
+        self.assertEqual(len(layout['dilution_2']['wells']), 50)
+        self.assertEqual(layout['dilution_1']['wells'], plate1.wells()[:50])
+        self.assertEqual(layout['dilution_2']['wells'], plate2.wells()[:50])
+
+    def test_two_dilutions_overflow_without_plate2_raises(self):
+        """Overflow without a second plate object provided must raise."""
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=2)
+        with self.assertRaises(ValueError) as ctx:
+            p.calculate_plate_layout(MagicMock(), MockPlate(), wells_per_dilution=50)
+        self.assertIn('plate2', str(ctx.exception))
+
+    def test_exactly_48_wells_fits_on_one_plate(self):
+        """
+        48 wells per dilution step is the boundary — both steps must share one plate.
+        """
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=2)
+        layout, _ = self._make_layout(p, wells_per_dilution=48)
+        self.assertEqual(layout['dilution_1']['plate'], 1)
+        self.assertEqual(layout['dilution_2']['plate'], 1)
+
+    def test_different_wells_per_dilution_for_dilution_and_agar(self):
+        """
+        Dilution plates use number_constructs wells; agar plates use
+        number_constructs × replicates wells. Both must be sliced correctly.
+        """
+        p = make_plating(THREE_CONSTRUCTS, replicates=4, number_dilutions=2)
+        dil_layout, dil_plate = self._make_layout(p, wells_per_dilution=3)   # constructs only
+        agar_layout, agar_plate = self._make_layout(p, wells_per_dilution=12)  # constructs × replicates
+
+        self.assertEqual(len(dil_layout['dilution_1']['wells']), 3)
+        self.assertEqual(len(agar_layout['dilution_1']['wells']), 12)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plating.py
+++ b/tests/test_plating.py
@@ -191,6 +191,24 @@ class TestDilutionFactor(unittest.TestCase):
         p = make_plating(dilution_factor=20, replicates=1, number_dilutions=2)
         self.assertAlmostEqual(p.volume_lb_transfer, 38.0)
 
+    def test_mix_volume_capped_at_19_for_default_factor(self):
+        """Default factor=10 → well=20 µL → mix_volume = min(19, 20-1) = 19."""
+        p = make_plating()
+        self.assertEqual(p.mix_volume, 19)
+
+    def test_mix_volume_capped_below_well_volume_for_small_factor(self):
+        """
+        factor=5, bacteria=2 → well=10 µL → mix_volume = min(19, 10-1) = 9.
+        Without this cap the mix step would try to aspirate 19 µL from a 10 µL well.
+        """
+        p = make_plating(dilution_factor=5)
+        self.assertEqual(p.mix_volume, 9)
+
+    def test_mix_volume_never_exceeds_19(self):
+        """Large factor → well volume > 20, but mix_volume is still capped at 19."""
+        p = make_plating(dilution_factor=20)  # well = 40 µL
+        self.assertEqual(p.mix_volume, 19)
+
 
 # ---------------------------------------------------------------------------
 # 4. Parameter merge hierarchy


### PR DESCRIPTION
…tion_factor param

- Change 2: use one tip for the entire LB distribution step (new_tip='never')
- Change 1: share each dilution well across all replicates; seed dilution2 before any agar aspirations; use a clean second tip for dilution-2 agar platings to prevent cross-concentration contamination; parameterise calculate_plate_layout with wells_per_dilution so dilution and agar plates expand independently
- Change 3: replace volume_lb_transfer with dilution_factor (default 10); derive volume_lb_transfer = volume_bacteria_transfer * (dilution_factor - 1); validate well volume sufficiency in __init__ and physical well capacity in run() via well.max_volume
- Add tests/test_plating.py: 32 unit tests covering init wiring, all validation limits, dilution_factor behaviour, param merge hierarchy, and plate layout logic