### PR TITLE
Add agar plate map outputs (JSON and Excel) to Plating protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ venv
 
 # Generated protocol output files produced by scripts/manual/ generators
 scripts/manual/*.md
+
+# Sphinx build output
+docs/_build/
+
+# Python cache
+__pycache__/
+*.pyc
+*.egg-info/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - test

--- a/docs/api/assembly.rst
+++ b/docs/api/assembly.rst
@@ -1,0 +1,46 @@
+pudu.assembly
+=============
+
+Classes for automated Golden Gate DNA assembly on the Opentrons OT-2.
+
+The module exposes four concrete classes and one factory:
+
+* :class:`~pudu.assembly.Domestication` — assembles individual parts into a universal acceptor backbone, one part at a time.
+* :class:`~pudu.assembly.ManualLoopAssembly` — combinatorial Loop Assembly from role-based part lists; detects Odd/Even receivers and selects the correct enzyme automatically.
+* :class:`~pudu.assembly.SBOLLoopAssembly` — explicit Loop Assembly from SBOL-format input; each assembly dict specifies parts, backbone, and enzyme directly.
+* :class:`~pudu.assembly.ManualAssembly` — generates a human-readable Markdown bench protocol (no OT-2 commands).
+* :class:`~pudu.assembly.LoopAssembly` — factory that auto-detects input format and returns the appropriate subclass.
+
+All OT-2 classes inherit from :class:`~pudu.assembly.BaseAssembly`, which
+implements shared hardware setup, tip management, and liquid transfer.
+
+.. autoclass:: pudu.assembly.BaseAssembly
+   :members:
+   :special-members: __init__
+
+.. autoclass:: pudu.assembly.Domestication
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.assembly.ManualLoopAssembly
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.assembly.SBOLLoopAssembly
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.assembly.ManualAssembly
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.assembly.LoopAssembly
+   :members:
+   :show-inheritance:
+
+.. autoclass:: pudu.assembly.ManualReactionRecord
+   :members:

--- a/docs/api/calibration.rst
+++ b/docs/api/calibration.rst
@@ -1,0 +1,33 @@
+pudu.calibration
+================
+
+Classes for automated plate-reader calibration following the iGEM 2022
+InterLab calibration protocol.
+
+Two protocols are provided:
+
+* :class:`~pudu.calibration.GFPODCalibration` — two calibrants (fluorescein
+  and silica microspheres), two replicates each; for GFP fluorescence and
+  OD600 calibration.
+* :class:`~pudu.calibration.RGBODCalibration` — four calibrants (fluorescein,
+  sulforhodamine 101, cascade blue, microspheres), two replicates each; for
+  RGB fluorescence and OD600 calibration.
+
+Both subclass :class:`~pudu.calibration.BaseCalibration` and use the
+template-method pattern: ``run()`` is implemented in the base class and calls
+abstract methods for the calibrant-specific steps.
+
+Reference protocol:
+`iGEM 2022 InterLab Calibration Protocol <https://old.igem.org/wiki/images/a/a4/InterLab_2022_-_Calibration_Protocol_v2.pdf>`_
+
+.. autoclass:: pudu.calibration.BaseCalibration
+   :members:
+   :special-members: __init__
+
+.. autoclass:: pudu.calibration.GFPODCalibration
+   :members:
+   :show-inheritance:
+
+.. autoclass:: pudu.calibration.RGBODCalibration
+   :members:
+   :show-inheritance:

--- a/docs/api/generate_protocol.rst
+++ b/docs/api/generate_protocol.rst
@@ -1,0 +1,12 @@
+pudu.generate_protocol
+======================
+
+Command-line tool and Python API for generating standalone Opentrons ``.py``
+protocol files from JSON inputs.
+
+See the module docstring below for the full CLI flag reference, JSON input
+formats, copy-paste terminal workflow, and Python API usage examples.
+
+.. automodule:: pudu.generate_protocol
+   :members:
+   :undoc-members: False

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,13 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   assembly
+   transformation
+   plating
+   calibration
+   sample_preparation
+   utils
+   generate_protocol

--- a/docs/api/plating.rst
+++ b/docs/api/plating.rst
@@ -1,0 +1,27 @@
+pudu.plating
+============
+
+Classes for automated and manual serial-dilution spot plating.
+
+* :class:`~pudu.plating.Plating` — OT-2 protocol that takes transformed
+  bacteria from a thermocycler plate, performs up to two serial dilutions,
+  and spots each dilution onto agar plates with replicates.
+* :class:`~pudu.plating.ManualPlating` — generates a human-readable Markdown
+  bench protocol.
+
+On simulation, :class:`~pudu.plating.Plating` writes:
+
+* ``{protocol_name}.json`` — machine-readable agar plate map
+* ``{protocol_name}.xlsx`` — colour-coded Excel grid (blue = dilution 1, orange = dilution 2)
+
+.. autoclass:: pudu.plating.Plating
+   :members:
+   :special-members: __init__
+
+.. autoclass:: pudu.plating.ManualPlating
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.plating.ManualPlatingRecord
+   :members:

--- a/docs/api/sample_preparation.rst
+++ b/docs/api/sample_preparation.rst
@@ -1,0 +1,28 @@
+pudu.sample_preparation
+========================
+
+Classes for distributing samples and creating inducer gradients on 96-well
+plates for characterisation experiments.
+
+* :class:`~pudu.sample_preparation.PlateSamples` — distributes a list of
+  samples into replicate wells across a plate.
+* :class:`~pudu.sample_preparation.PlateWithGradient` — creates a serial
+  inducer-concentration gradient (e.g. IPTG dose-response) across replicate
+  rows on a 96-well plate.
+
+Both subclass :class:`~pudu.sample_preparation.SamplePreparation`, which
+provides shared labware loading and well-slot management.
+
+.. autoclass:: pudu.sample_preparation.SamplePreparation
+   :members:
+   :special-members: __init__
+
+.. autoclass:: pudu.sample_preparation.PlateSamples
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.sample_preparation.PlateWithGradient
+   :members:
+   :special-members: __init__
+   :show-inheritance:

--- a/docs/api/transformation.rst
+++ b/docs/api/transformation.rst
@@ -1,0 +1,37 @@
+pudu.transformation
+===================
+
+Classes for automated and manual bacterial heat-shock transformation.
+
+* :class:`~pudu.transformation.HeatShockTransformation` — OT-2 protocol that
+  loads DNA and competent cells into a thermocycler plate, runs the heat-shock
+  cycle, adds recovery media, and exports a plating map.
+* :class:`~pudu.transformation.ManualTransformation` — generates a
+  human-readable Markdown bench protocol.
+
+Both classes accept SBOL-style transformation data of the form::
+
+    [
+        {
+            "Strain":   "https://SBOL2Build.org/strain_GFP/1",
+            "Chassis":  "https://sbolcanvas.org/DH5alpha/1",
+            "Plasmids": ["https://SBOL2Build.org/composite_1/1"]
+        }
+    ]
+
+.. autoclass:: pudu.transformation.Transformation
+   :members:
+   :special-members: __init__
+
+.. autoclass:: pudu.transformation.HeatShockTransformation
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.transformation.ManualTransformation
+   :members:
+   :special-members: __init__
+   :show-inheritance:
+
+.. autoclass:: pudu.transformation.ManualTransformationRecord
+   :members:

--- a/docs/api/utils.rst
+++ b/docs/api/utils.rst
@@ -1,0 +1,22 @@
+pudu.utils
+==========
+
+Shared utilities used across PUDU protocols.
+
+* :class:`~pudu.utils.Camera` — captures images and records video via ffmpeg
+  during OT-2 protocol runs.
+* :class:`~pudu.utils.SmartPipette` — pipette wrapper that uses the
+  Opentrons liquid-tracking API to compute safe aspiration heights for
+  conical tubes, preventing tip plunging as tubes empty.
+* ``colors`` — list of 24 hex colour strings used to colour-code liquids in
+  the Opentrons deck visualiser.
+
+.. autodata:: pudu.utils.colors
+
+.. autoclass:: pudu.utils.Camera
+   :members:
+   :special-members: __init__
+
+.. autoclass:: pudu.utils.SmartPipette
+   :members:
+   :special-members: __init__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+# Point Sphinx at the src layout so autodoc can import pudu
+sys.path.insert(0, os.path.abspath('../src'))
+
+# ---------------------------------------------------------------------------
+# Project info
+# ---------------------------------------------------------------------------
+project = 'PUDU'
+copyright = '2024, Gonzalo Vidal, Oscar Rodriguez'
+author = 'Gonzalo Vidal, Oscar Rodriguez'
+release = '1.0.0b9'
+
+# ---------------------------------------------------------------------------
+# Extensions
+# ---------------------------------------------------------------------------
+extensions = [
+    'sphinx.ext.autodoc',      # Pull docstrings from source
+    'sphinx.ext.napoleon',     # Support Google-style docstrings (Args:, Returns:, etc.)
+    'sphinx.ext.viewcode',     # Add [source] links next to every API entry
+    'sphinx.ext.intersphinx',  # Cross-reference Python standard library docs
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}
+
+# ---------------------------------------------------------------------------
+# autodoc settings
+# ---------------------------------------------------------------------------
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': False,   # Hide members with no docstring
+    'show-inheritance': True,
+    'member-order': 'bysource',  # Preserve definition order, not alphabetical
+}
+autodoc_typehints = 'description'  # Show type hints in the parameter descriptions
+
+# Napoleon settings (Google-style docstrings)
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+napoleon_include_init_with_doc = True   # Include __init__ docstring in class page
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+# ---------------------------------------------------------------------------
+# HTML output
+# ---------------------------------------------------------------------------
+html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    'navigation_depth': 3,
+    'titles_only': False,
+}
+
+html_static_path = ['_static']
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -1,0 +1,8 @@
+User Guide
+==========
+
+.. toctree::
+   :maxdepth: 2
+
+   installation
+   workflow

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -1,0 +1,50 @@
+Installation
+============
+
+Computer (development / simulation)
+-------------------------------------
+
+Install PUDU from PyPI::
+
+    pip install pudupy
+
+To run simulations on your laptop without a physical robot::
+
+    opentrons_simulate your_protocol.py
+
+OT-2 robot
+-----------
+
+SSH into the OT-2 (first-time setup: `Opentrons SSH guide
+<https://support.opentrons.com/s/article/Setting-up-SSH-access-to-your-OT-2>`_),
+then install::
+
+    pip install pudupy
+
+The robot and your laptop must be on the same local network so the Opentrons
+App can detect the robot.
+
+Dependencies
+------------
+
+PUDU depends on:
+
+* ``opentrons >= 8.4.1``
+* ``xlsxwriter >= 3.2.5``
+
+For building this documentation locally::
+
+    pip install sphinx sphinx-rtd-theme
+
+Developer install
+-----------------
+
+Clone the repository and install in editable mode::
+
+    git clone https://github.com/MyersResearchGroup/PUDU.git
+    cd PUDU
+    pip install -e ".[test]"
+
+Run the test suite::
+
+    pytest tests/

--- a/docs/guide/workflow.rst
+++ b/docs/guide/workflow.rst
@@ -1,0 +1,118 @@
+End-to-end workflow
+===================
+
+PUDU automates three sequential lab stages.  Each stage reads the output of
+the previous one, creating a traceable chain from DNA design to plated
+colonies.
+
+.. code-block:: text
+
+    SBOL JSON design
+         │
+         ▼
+    ┌─────────────┐     opentrons_simulate
+    │  Assembly   │ ──────────────────────▶  transformation_input.json
+    └─────────────┘
+         │
+         ▼
+    ┌──────────────────┐  opentrons_simulate
+    │  Transformation  │ ──────────────────▶  plating_input.json
+    └──────────────────┘
+         │
+         ▼
+    ┌─────────┐  opentrons_simulate
+    │ Plating │ ──────────────────────────▶  plating_layout.json / .xlsx
+    └─────────┘
+
+Stage 1 — Assembly
+------------------
+
+Golden Gate DNA assembly in a thermocycler.  Parts and backbone are loaded
+onto a temperature module (4 °C), combined in a thermocycler plate, and
+cycled 75 times between 42 °C (digest) and 16 °C (ligate).
+
+Generate and simulate the protocol::
+
+    python -m pudu.generate_protocol \
+        scripts/manual/manual_assembly_input.json \
+        -o assembly_protocol.py \
+        --protocol-type assembly
+
+    opentrons_simulate assembly_protocol.py
+
+This writes ``transformation_input.json`` mapping each assembled product URI
+to its thermocycler well location.
+
+Stage 2 — Transformation
+-------------------------
+
+Heat-shock transformation of assembled plasmids into competent bacteria.
+DNA is transferred from the assembly plate (or temp module) into the
+thermocycler plate alongside competent cells, heat-shocked, and incubated
+with recovery media.
+
+Generate and simulate::
+
+    python -m pudu.generate_protocol \
+        scripts/manual/manual_transformation_input.json \
+        -o transformation_protocol.py \
+        --protocol-type transformation \
+        --plasmid-locations transformation_input.json
+
+    opentrons_simulate transformation_protocol.py
+
+This writes ``plating_input.json`` mapping each thermocycler well to its
+transformed construct.
+
+Stage 3 — Plating
+------------------
+
+Serial dilution and spot-plating onto agar.  Bacteria from the thermocycler
+plate are diluted (up to 2×) and spotted onto agar plates with replicates.
+
+Generate and simulate::
+
+    python -m pudu.generate_protocol \
+        plating_input.json \
+        -o plating_protocol.py \
+        --protocol-type plating
+
+    opentrons_simulate plating_protocol.py
+
+This writes ``plating_layout.json`` and ``plating_layout.xlsx`` — a coloured
+grid showing which agar well receives which construct at which dilution ratio.
+
+Manual bench protocols
+-----------------------
+
+If you don't have access to an OT-2, PUDU can generate human-readable
+Markdown guides for each stage::
+
+    python scripts/manual/generate_manual_assembly_protocol.py \
+        --input  scripts/manual/manual_assembly_input.json \
+        --output scripts/manual/manual_assembly_protocol.md
+
+    python scripts/manual/generate_manual_transformation_protocol.py \
+        --input  scripts/manual/manual_transformation_input.json \
+        --output scripts/manual/manual_transformation_protocol.md
+
+    python scripts/manual/generate_manual_plating_protocol.py \
+        --input  scripts/manual/manual_plating_input.json \
+        --output scripts/manual/manual_plating_protocol.md
+
+Input file formats
+------------------
+
+See :mod:`pudu.generate_protocol` for the full JSON schemas for each input
+type and the advanced parameters file.
+
+Calibration
+-----------
+
+Before running fluorescence or OD600 measurements, calibrate your plate
+reader using the iGEM 2022 protocol.  Two calibration classes are provided:
+
+* :class:`pudu.calibration.GFPODCalibration` — fluorescein + microspheres (GFP + OD600)
+* :class:`pudu.calibration.RGBODCalibration` — fluorescein + sulforhodamine + cascade blue + microspheres
+
+Example script: ``scripts/automated_ot2/run_iGEM_rgb_od.py``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,30 @@
+PUDU — Protocol Unified Design Unit
+=====================================
+
+.. image:: https://img.shields.io/pypi/v/pudupy
+   :alt: PyPI version
+
+PUDU is a Python package for automating synthetic biology liquid-handling
+workflows on the Opentrons OT-2 robot.  It covers the full three-stage
+pipeline — **DNA assembly → bacterial transformation → agar plating** — and
+can generate both automated OT-2 protocols and human-readable Markdown bench
+guides from the same SBOL-style JSON input.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
+   guide/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API Reference
+
+   api/index
+
+Indices and search
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=5.0
+sphinx-rtd-theme>=1.3

--- a/src/pudu/assembly.py
+++ b/src/pudu/assembly.py
@@ -58,6 +58,49 @@ class BaseAssembly(ABC):
                  water_testing: bool = False,
                  output_xlsx: bool = True,
                  protocol_name: str = ''):
+        """
+        Initialize shared assembly protocol parameters.
+
+        Parameters provided via ``json_params`` take precedence over defaults but are
+        overridden by any keyword argument that differs from its default value.
+
+        Args:
+            json_params: Optional dict of parameter overrides loaded from a JSON
+                config file. Keys must match the parameter names listed below.
+            volume_total_reaction: Total volume of each assembly reaction in µL.
+            volume_part: Volume of each DNA part (and backbone) added per reaction in µL.
+            volume_restriction_enzyme: Volume of restriction enzyme per reaction in µL.
+            volume_t4_dna_ligase: Volume of T4 DNA ligase per reaction in µL.
+            volume_t4_dna_ligase_buffer: Volume of T4 DNA ligase buffer per reaction in µL.
+            replicates: Number of reaction replicates per unique assembly combination.
+            thermocycler_starting_well: Zero-based index of the first well to use in the
+                thermocycler plate. Useful when chaining multiple protocols on one plate.
+            thermocycler_labware: Opentrons labware definition string for the thermocycler
+                plate.
+            temperature_module_labware: Opentrons labware definition string for the
+                aluminum block loaded on the temperature module.
+            temperature_module_position: Deck slot number (as a string) for the
+                temperature module.
+            tiprack_labware: Opentrons labware definition string for tip racks.
+            tiprack_positions: List of deck slot strings for tip racks. Defaults to
+                ``['2', '3', '4', '5', '6', '9']`` when ``None``.
+            pipette: Opentrons pipette model string (e.g. ``'p20_single_gen2'``).
+            pipette_position: Mount side for the pipette (``'left'`` or ``'right'``).
+            initial_tip: Well name of the first tip to use on the first rack (e.g.
+                ``'B1'``). When ``None``, starts from the first available tip (``'A1'``).
+            aspiration_rate: Aspiration speed as a fraction of the pipette's maximum
+                flow rate (``1.0`` = full speed). Lower values reduce bubble formation.
+            dispense_rate: Dispense speed as a fraction of the pipette's maximum flow
+                rate.
+            take_picture: If ``True``, capture an image at the start and end of the
+                protocol using the OT-2 camera.
+            take_video: If ``True``, record video for the duration of the protocol.
+            water_testing: If ``True``, skip temperature control and thermocycling so
+                the protocol can be simulated with water as a dry run.
+            output_xlsx: If ``True``, write an Excel file summarising the deck layout
+                during simulation.
+            protocol_name: Base name used for output files (e.g. the Excel workbook).
+        """
 
         kwargs_params = {
             'volume_total_reaction': volume_total_reaction,
@@ -369,6 +412,29 @@ class BaseAssembly(ABC):
                         mix_before: float = 0.0, mix_after: float = 0.0,
                         mix_reps: int = 3, new_tip: bool = True,
                         drop_tip: bool = True):
+        """
+        Aspirate from *source* and dispense into *dest* with optional mixing and tip management.
+
+        Automatically triggers a tip-rack batch swap when the current racks are exhausted
+        (see ``setup_tip_management``).
+
+        Args:
+            protocol: Opentrons ``ProtocolContext`` used for comments and labware moves.
+            pipette: Loaded pipette instrument object.
+            volume: Volume to transfer in µL.
+            source: Source well or location object.
+            dest: Destination well or location object.
+            asp_rate: Aspiration speed as a fraction of max flow rate.
+            disp_rate: Dispense speed as a fraction of max flow rate.
+            blow_out: If ``True``, blow out after dispensing to clear the tip.
+            touch_tip: If ``True``, touch the tip to the well wall after dispensing to
+                remove hanging droplets.
+            mix_before: If > 0, mix this volume at *source* before aspirating.
+            mix_after: If > 0, mix this volume at *dest* after dispensing.
+            mix_reps: Number of mix repetitions when ``mix_before`` or ``mix_after`` > 0.
+            new_tip: If ``True``, pick up a fresh tip before the transfer.
+            drop_tip: If ``True``, drop the tip after the transfer.
+        """
         if new_tip:
             if self._check_if_swap_needed():
                 self._perform_tip_rack_batch_swap(protocol)
@@ -605,7 +671,7 @@ class Domestication(BaseAssembly):
             assembly_data: Dict containing 'assemblies' key (new standardized approach)
             advanced_params: Optional advanced parameters
             assemblies: List of assembly dicts (backward compatibility)
-            *args, **kwargs: Passed to BaseAssembly
+            \*args, \*\*kwargs: Passed to BaseAssembly
         """
         # Handle parameter precedence: assembly_data <- assemblies kwarg
         if assembly_data is not None:
@@ -843,7 +909,7 @@ class ManualLoopAssembly(BaseAssembly):
             assembly_data: Dict containing 'assemblies' key (new standardized approach)
             json_params: Optional advanced parameters
             assemblies: List of assembly dicts (backward compatibility)
-            *args, **kwargs: Passed to BaseAssembly
+            \*args, \*\*kwargs: Passed to BaseAssembly
         """
         # Handle parameter precedence: assembly_data <- assemblies kwarg
         if assembly_data is not None:
@@ -1111,7 +1177,7 @@ class SBOLLoopAssembly(BaseAssembly):
             assembly_data: Dict containing 'assemblies' key (new standardized approach)
             advanced_params: Optional advanced parameters
             assemblies: List of assembly dicts (backward compatibility)
-            *args, **kwargs: Passed to BaseAssembly
+            \*args, \*\*kwargs: Passed to BaseAssembly
         """
         # Handle parameter precedence: assembly_data <- assemblies kwarg
         if assembly_data is not None:

--- a/src/pudu/calibration.py
+++ b/src/pudu/calibration.py
@@ -8,7 +8,8 @@ class BaseCalibration(ABC):
     """
     Abstract base class for calibration protocols.
     Contains shared hardware setup, liquid handling, and serial dilution functionality.
-    Refer to: https://old.igem.org/wiki/images/a/a4/InterLab_2022_-_Calibration_Protocol_v2.pdf
+    Reference: `iGEM 2022 InterLab Calibration Protocol
+    <https://old.igem.org/wiki/images/a/a4/InterLab_2022_-_Calibration_Protocol_v2.pdf>`_
     """
 
     def __init__(self,
@@ -28,7 +29,39 @@ class BaseCalibration(ABC):
                  take_picture: bool = False,
                  take_video: bool = False,
                  water_testing: bool = False):
+        """
+        Initialize shared calibration protocol parameters.
 
+        Args:
+            aspiration_rate: Aspiration speed as a fraction of the pipette's
+                maximum flow rate (``1.0`` = full speed). Lower values reduce
+                bubble formation with viscous calibrants.
+            dispense_rate: Dispense speed as a fraction of the pipette's maximum
+                flow rate.
+            tiprack_labware: Opentrons labware definition string for the tip rack.
+            tiprack_position: Deck slot string for the tip rack.
+            pipette: Opentrons pipette model string (e.g. ``'p300_single_gen2'``).
+            pipette_position: Mount side for the pipette (``'left'`` or ``'right'``).
+            calibration_plate_labware: Opentrons labware definition string for the
+                96-well calibration plate where serial dilutions are performed.
+            calibration_plate_position: Deck slot string for the calibration plate.
+            tube_rack_labware: Opentrons labware definition string for the 24-well
+                aluminum block / tube rack holding calibrant stocks and buffers.
+            tube_rack_position: Deck slot string for the tube rack.
+            use_falcon_tubes: If ``True``, PBS and water buffers are sourced from
+                50 mL Falcon tubes instead of 1.5 mL microtubes. Enables the
+                ``SmartPipette`` conical-tube height calculation for accurate
+                aspiration as the tube empties.
+            falcon_tube_rack_labware: Opentrons labware definition string for the
+                Falcon tube rack. Only used when ``use_falcon_tubes=True``.
+            falcon_tube_rack_position: Deck slot string for the Falcon tube rack.
+            take_picture: If ``True``, capture an image at the start and end of
+                the protocol.
+            take_video: If ``True``, record video for the duration of the protocol.
+            water_testing: If ``True``, skip any steps that require real reagents
+                (reserved for future dry-run support; not fully implemented in all
+                subclasses).
+        """
         self.aspiration_rate = aspiration_rate
         self.dispense_rate = dispense_rate
         self.tiprack_labware = tiprack_labware

--- a/src/pudu/generate_protocol.py
+++ b/src/pudu/generate_protocol.py
@@ -1,18 +1,287 @@
 """
 Protocol Generator for PUDU
+============================
 
-Generates standalone Opentrons protocol files from JSON inputs.
-The generated protocols can be uploaded directly to the Opentrons App.
+Generates standalone Opentrons OT-2 protocol ``.py`` files from JSON inputs.
+The generated files can be uploaded directly to the Opentrons App or simulated
+on a laptop to verify the deck layout before running on the robot.
 
-Usage:
-    # Assembly protocols
-    python -m pudu.generate_protocol input.json [params.json] -o output.py --protocol-type assembly
+This module supports two usage modes:
 
-    # Transformation protocols
-    python -m pudu.generate_protocol input.json [params.json] -o output.py --protocol-type transformation
+* **Command-line** (recommended) — run as ``python -m pudu.generate_protocol``
+* **Python API** — call :func:`generate_protocol` programmatically from a script
+  or notebook (see the API section below)
 
-    # Plating protocols
-    python -m pudu.generate_protocol input.json [params.json] -o output.py --protocol-type plating
+
+Overview of the three protocol stages
+--------------------------------------
+
+A typical PUDU synthetic-biology workflow has three sequential stages that each
+produce a robot protocol file:
+
+1. **Assembly** — Golden Gate DNA assembly in a thermocycler.  Outputs
+   ``transformation_input.json`` (well locations of assembled products).
+2. **Transformation** — Heat-shock transformation of assembled DNA into competent
+   bacteria.  Outputs ``plating_input.json`` (thermocycler well locations of
+   transformed cultures).
+3. **Plating** — Serial dilution and spot-plating onto agar plates.
+
+
+Input file formats
+-------------------
+
+**Assembly input** (SBOL-style list of constructs)::
+
+    [
+        {
+            "Product":            "https://SBOL2Build.org/composite_1/1",
+            "Backbone":           "https://sbolcanvas.org/pSB1C3/1",
+            "PartsList": [
+                "https://sbolcanvas.org/J23101/1",
+                "https://sbolcanvas.org/B0034/1",
+                "https://sbolcanvas.org/GFP/1",
+                "https://sbolcanvas.org/B0015/1"
+            ],
+            "Restriction Enzyme": "https://SBOL2Build.org/BsaI/1"
+        }
+    ]
+
+**Transformation input** (list of strain/chassis/plasmid mappings)::
+
+    [
+        {
+            "Strain":   "https://SBOL2Build.org/strain_GFP/1",
+            "Chassis":  "https://sbolcanvas.org/DH5alpha/1",
+            "Plasmids": ["https://SBOL2Build.org/composite_1/1"]
+        }
+    ]
+
+**Plating input** (bacterium locations from transformation output)::
+
+    {
+        "bacterium_locations": {
+            "A1": "https://SBOL2Build.org/composite_1/1",
+            "B1": "https://SBOL2Build.org/composite_2/1"
+        }
+    }
+
+**Advanced parameters** (optional ``json_params`` file — any protocol type)::
+
+    {
+        "replicates": 2,
+        "volume_part": 3,
+        "initial_tip": "B1",
+        "protocol_name": "GFP_RFP_assembly"
+    }
+
+**Metadata** (optional ``--metadata`` file — any protocol type)::
+
+    {
+        "protocolName": "GFP RFP Assembly",
+        "author": "Oscar Rodriguez",
+        "description": "Loop assembly of GFP and RFP constructs",
+        "apiLevel": "2.21"
+    }
+
+All four keys are optional; omitted keys fall back to the defaults in
+``DEFAULT_METADATA``.
+
+
+Full automated OT-2 workflow (terminal commands)
+-------------------------------------------------
+
+Run all commands from the repository root (the directory containing ``src/``).
+
+**Step 1 — Generate the assembly protocol**::
+
+    python -m pudu.generate_protocol \\
+        scripts/manual/manual_assembly_input.json \\
+        -o assembly_protocol.py \\
+        --protocol-type assembly
+
+Pass a parameters file as the **second positional argument** to override
+defaults (volumes, replicates, starting tip, etc.)::
+
+    python -m pudu.generate_protocol \\
+        scripts/manual/manual_assembly_input.json \\
+        my_params.json \\
+        -o assembly_protocol.py \\
+        --protocol-type assembly
+
+Override the Opentrons metadata (protocol name shown in the app, author,
+API level) with ``--metadata``::
+
+    python -m pudu.generate_protocol \\
+        scripts/manual/manual_assembly_input.json \\
+        -o assembly_protocol.py \\
+        --protocol-type assembly \\
+        --metadata my_metadata.json
+
+Force a specific assembly subtype with ``--assembly-type`` (useful when
+auto-detection is ambiguous)::
+
+    python -m pudu.generate_protocol \\
+        scripts/manual/manual_assembly_input.json \\
+        -o domestication_protocol.py \\
+        --protocol-type assembly \\
+        --assembly-type Domestication
+
+**Step 1a — Simulate the assembly protocol to produce plasmid locations**::
+
+    opentrons_simulate assembly_protocol.py
+
+This writes ``transformation_input.json`` in the current directory.
+
+**Step 2 — Generate the transformation protocol**
+
+Without assembly output (plasmids loaded manually onto the temperature module)::
+
+    python -m pudu.generate_protocol \\
+        scripts/manual/manual_transformation_input.json \\
+        -o transformation_protocol.py \\
+        --protocol-type transformation
+
+With assembly output (plasmids sourced from the 96-well PCR plate at the
+exact well positions recorded by the assembly simulation)::
+
+    python -m pudu.generate_protocol \\
+        scripts/manual/manual_transformation_input.json \\
+        -o transformation_protocol.py \\
+        --protocol-type transformation \\
+        --plasmid-locations transformation_input.json
+
+**Step 2a — Simulate to produce bacteria locations**::
+
+    opentrons_simulate transformation_protocol.py
+
+This writes ``plating_input.json`` in the current directory.
+
+**Step 3 — Generate the plating protocol**::
+
+    python -m pudu.generate_protocol \\
+        plating_input.json \\
+        -o plating_protocol.py \\
+        --protocol-type plating
+
+**Step 3a — Simulate to verify the agar plate map**::
+
+    opentrons_simulate plating_protocol.py
+
+This writes ``plating_layout.json`` and ``plating_layout.xlsx`` showing which
+well on which agar plate receives which construct at which dilution.
+
+
+Manual (bench) protocol generation
+------------------------------------
+
+PUDU can also produce human-readable **Markdown** protocols for manual bench
+work, without any OT-2 involvement.
+
+**Manual assembly protocol**::
+
+    python scripts/manual/generate_manual_assembly_protocol.py \\
+        --input  scripts/manual/manual_assembly_input.json \\
+        --output scripts/manual/manual_assembly_protocol.md
+
+**Manual transformation protocol**::
+
+    python scripts/manual/generate_manual_transformation_protocol.py \\
+        --input  scripts/manual/manual_transformation_input.json \\
+        --output scripts/manual/manual_transformation_protocol.md
+
+**Manual plating protocol**::
+
+    python scripts/manual/generate_manual_plating_protocol.py \\
+        --input  scripts/manual/manual_plating_input.json \\
+        --output scripts/manual/manual_plating_protocol.md
+
+
+Python API usage
+-----------------
+
+You can call :func:`generate_protocol` directly from a script or Jupyter
+notebook and write the result yourself::
+
+    import json
+    from pudu.generate_protocol import generate_protocol, detect_protocol_type
+
+    with open("scripts/manual/manual_assembly_input.json") as f:
+        data = json.load(f)
+
+    protocol_type, assembly_subtype = detect_protocol_type(data)
+
+    code = generate_protocol(
+        protocol_data=data,
+        protocol_type=protocol_type,
+        assembly_subtype=assembly_subtype,
+        json_params={"replicates": 2, "volume_part": 3},
+    )
+
+    with open("assembly_protocol.py", "w") as f:
+        f.write(code)
+
+
+CLI flag reference
+-------------------
+
+Positional arguments (order matters, both must come before any flags):
+
+``input``
+    **Required.** Path to the primary protocol data JSON file (assembly list,
+    transformation list, or plating dict).
+
+``json_params``
+    **Optional.** Path to an advanced parameters JSON file.  Must be the
+    *second positional argument* — placed immediately after ``input`` and
+    before any ``--flag``.  Keys must match the ``__init__`` parameter names
+    of the target protocol class (see the parameter reference block appended
+    to every generated ``.py`` file for the full list).
+
+Named flags:
+
+``-o`` / ``--output``
+    **Required.** Destination path for the generated ``.py`` protocol file
+    (e.g. ``-o assembly_protocol.py``).
+
+``--protocol-type``
+    Choices: ``assembly``, ``transformation``, ``plating``.
+    When omitted, the type is auto-detected from the input JSON structure
+    (see *Auto-detect rules* below).
+
+``--assembly-type``
+    Choices: ``SBOL``, ``Manual``, ``Domestication``.
+    Only relevant when ``--protocol-type assembly`` is used.  When omitted,
+    the subtype is auto-detected from the assembly input keys.  Pass
+    explicitly when the input is ambiguous (e.g. a Domestication JSON whose
+    keys happen to overlap with SBOL format).
+
+``--plasmid-locations``
+    Path to the ``transformation_input.json`` produced by simulating an
+    assembly protocol.  When provided, the generated transformation protocol
+    reads DNA directly from the assembly output plate at its fixed well
+    positions instead of sequentially from the temperature module.  Only
+    applicable with ``--protocol-type transformation``.
+
+``--metadata``
+    Path to a JSON file with Opentrons protocol metadata.  Valid keys:
+    ``protocolName``, ``author``, ``description``, ``apiLevel``.  Any key
+    omitted here falls back to the default in ``DEFAULT_METADATA``.  The
+    metadata appears in the Opentrons App header and simulation output.
+
+
+Auto-detect rules
+------------------
+
+When ``--protocol-type`` is omitted, :func:`detect_protocol_type` inspects the
+JSON keys to guess the type:
+
+* List with ``"Product"`` / ``"Backbone"`` / ``"PartsList"`` / ``"Restriction Enzyme"`` → **SBOL assembly**
+* List with ``"receiver"`` key → **Manual/combinatorial assembly**
+* List with ``"parts"`` / ``"backbone"`` / ``"restriction_enzyme"`` keys → **Domestication assembly**
+* List with ``"Strain"`` / ``"Chassis"`` / ``"Plasmids"`` → **Transformation**
+* Dict with ``"bacterium_locations"`` key → **Plating**
+
+Pass ``--protocol-type`` explicitly when the auto-detection is ambiguous.
 """
 
 import json
@@ -305,18 +574,49 @@ def generate_protocol(
     plasmid_locations: Optional[Dict] = None
 ) -> str:
     """
-    Generate a complete Opentrons protocol file as a string.
+    Generate a complete Opentrons protocol file as a Python source string.
+
+    The returned string is a self-contained ``.py`` file that can be written
+    to disk and uploaded to the Opentrons App or passed to
+    ``opentrons_simulate``.  It contains:
+
+    * The protocol data embedded as a Python literal.
+    * An optional ``json_params`` dict (when provided) embedded as a literal.
+    * An optional ``plasmid_locations`` dict (transformation only).
+    * A ``metadata`` dict for the Opentrons App.
+    * A ``run()`` function that instantiates the correct PUDU class and calls
+      its ``.run()`` method.
+    * A commented parameter-reference block at the end listing every available
+      constructor parameter with its type and default value.
 
     Args:
-        protocol_data: Protocol data (list for assemblies, or dict for other protocols)
-        json_params: Optional advanced parameters dictionary
-        metadata: Optional metadata dictionary (merged with defaults)
-        protocol_type: Type of protocol ('assembly', 'transformation', 'plating')
-        assembly_subtype: Subtype for assembly protocols ('SBOL', 'Manual', 'Domestication')
-        plasmid_locations: Optional dict mapping plasmid URIs to well locations (from assembly output)
+        protocol_data: The primary protocol payload.  For assembly and
+            transformation protocols this is a list of dicts; for plating it
+            is a dict with a ``"bacterium_locations"`` key.
+        json_params: Dict of parameter overrides to embed in the generated
+            file.  Keys must match the ``__init__`` parameters of the target
+            protocol class.  These are passed as ``json_params=json_params``
+            in the generated constructor call.
+        metadata: Dict of Opentrons metadata keys to merge over the defaults
+            in ``DEFAULT_METADATA``.  Valid keys: ``protocolName``,
+            ``author``, ``description``, ``apiLevel``.
+        protocol_type: One of ``'assembly'``, ``'transformation'``, or
+            ``'plating'``.
+        assembly_subtype: Required when ``protocol_type='assembly'``.  One of
+            ``'SBOL'``, ``'Manual'``, or ``'Domestication'``.
+        plasmid_locations: Dict mapping plasmid URIs (strings) to lists of
+            well names, as produced by simulating an assembly protocol
+            (``transformation_input.json``).  When provided, the generated
+            transformation protocol sources DNA from the assembly output plate
+            at its fixed positions instead of sequentially from the temp
+            module.  Ignored for non-transformation protocol types.
 
     Returns:
-        Complete protocol file as a string
+        The complete protocol file as a Python source string.
+
+    Raises:
+        ValueError: If ``protocol_type`` is not recognised, or if
+            ``assembly_subtype`` is ``None`` when ``protocol_type='assembly'``.
     """
     # Get protocol configuration
     if protocol_type not in PROTOCOL_CONFIGS:
@@ -419,7 +719,14 @@ def generate_protocol(
     return '\n'.join(lines)
 
 def main():
-    """Command-line interface for protocol generation"""
+    """
+    Entry point for ``python -m pudu.generate_protocol``.
+
+    Parses command-line arguments, loads the input JSON files, calls
+    :func:`generate_protocol`, and writes the result to the output path.
+    See the module docstring for full usage, flag descriptions, and
+    copy-paste workflow examples.
+    """
     parser = argparse.ArgumentParser(
         description='Generate Opentrons protocol files from JSON inputs',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/pudu/plating.py
+++ b/src/pudu/plating.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional, Dict, List
 from dataclasses import dataclass
 from pudu import colors, SmartPipette
@@ -50,6 +51,7 @@ class Plating():
                  aspiration_rate: float = 0.5,
                  dispense_rate: float = 1,
                  bacterium_locations: Optional[Dict] = None,
+                 protocol_name: str = 'plating_layout',
                  **kwargs):
 
         # Collect kwargs for merging
@@ -85,7 +87,8 @@ class Plating():
             'lb_tube_position': lb_tube_position,
             'aspiration_rate': aspiration_rate,
             'dispense_rate': dispense_rate,
-            'bacterium_locations': bacterium_locations
+            'bacterium_locations': bacterium_locations,
+            'protocol_name': protocol_name,
         }
 
         kwargs_params.update(kwargs)
@@ -133,6 +136,7 @@ class Plating():
         self.bacterium_locations = self._merged_params['bacterium_locations']
         self.number_constructs = len(self.bacterium_locations)
         self.max_colonies = self._merged_params['max_colonies']
+        self.protocol_name = self._merged_params['protocol_name']
 
         self.total_colonies = self.number_constructs * self.number_dilutions * self.replicates
 
@@ -203,7 +207,8 @@ class Plating():
             'lb_tube_position': 0,
             'aspiration_rate': 0.5,
             'dispense_rate': 1,
-            'bacterium_locations': None
+            'bacterium_locations': None,
+            'protocol_name': 'plating_layout',
         }
 
         # Start with defaults
@@ -288,6 +293,144 @@ class Plating():
             # Single dilution step
             layout['dilution_1']['wells'] = plate1.wells()[:wells_per_dilution]
         return layout
+
+    @staticmethod
+    def _well_name_from_index(idx: int) -> str:
+        row = idx % 8
+        col = idx // 8
+        return f"{'ABCDEFGH'[row]}{col + 1}"
+
+    @staticmethod
+    def _format_construct_name(construct_names) -> str:
+        if isinstance(construct_names, (list, tuple)):
+            return ', '.join(str(x) for x in construct_names)
+        return str(construct_names)
+
+    def _dilution_ratio_label(self, dilution_step: int) -> str:
+        factor = self.dilution_factor ** dilution_step
+        factor_int = int(factor) if float(factor).is_integer() else factor
+        return f"1/{factor_int}"
+
+    def build_agar_plate_map(self) -> Dict:
+        constructs = list(self.bacterium_locations.items())
+        agar_wells_per = self.number_constructs * self.replicates
+        plates: Dict = {}
+
+        for dilution_step in range(1, self.number_dilutions + 1):
+            if self.number_dilutions == 2 and agar_wells_per > 48:
+                plate_key = f'plate_{dilution_step}'
+                start_idx = 0
+            else:
+                plate_key = 'plate_1'
+                start_idx = 0 if dilution_step == 1 else 48
+
+            ratio = self._dilution_ratio_label(dilution_step)
+            dilution_key = f'dilution_{dilution_step}'
+
+            if plate_key not in plates:
+                plates[plate_key] = {}
+            plates[plate_key][dilution_key] = {'ratio': ratio, 'wells': {}}
+
+            for construct_idx, (source_well, construct_names) in enumerate(constructs):
+                name_str = self._format_construct_name(construct_names)
+                for replicate in range(self.replicates):
+                    well_idx = start_idx + construct_idx * self.replicates + replicate
+                    well_name = self._well_name_from_index(well_idx)
+                    plates[plate_key][dilution_key]['wells'][well_name] = {
+                        'construct': name_str,
+                        'source_well': source_well,
+                        'replicate': replicate + 1,
+                    }
+
+        return plates
+
+    def get_plates_json(self) -> Dict:
+        return {'agar_plates': self.build_agar_plate_map()}
+
+    def write_plates_json(self, output_path: str) -> Dict:
+        data = self.get_plates_json()
+        with open(output_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        return data
+
+    def write_plates_excel(self, output_path: str) -> None:
+        try:
+            import xlsxwriter
+        except ImportError:
+            raise ImportError("xlsxwriter is required. Install with: pip install xlsxwriter")
+
+        plates_data = self.build_agar_plate_map()
+        workbook = xlsxwriter.Workbook(output_path)
+        worksheet = workbook.add_worksheet('Agar Plates')
+
+        title_fmt = workbook.add_format({
+            'bold': True, 'font_size': 12,
+            'bg_color': '#4472C4', 'font_color': 'white',
+            'align': 'center', 'valign': 'vcenter', 'border': 1,
+        })
+        header_fmt = workbook.add_format({
+            'bold': True, 'bg_color': '#D9E1F2',
+            'align': 'center', 'valign': 'vcenter', 'border': 1,
+        })
+        well_fmts = {
+            1: workbook.add_format({
+                'align': 'center', 'valign': 'vcenter', 'text_wrap': True,
+                'bg_color': '#BDD7EE', 'border': 1,
+            }),
+            2: workbook.add_format({
+                'align': 'center', 'valign': 'vcenter', 'text_wrap': True,
+                'bg_color': '#FCE4D6', 'border': 1,
+            }),
+        }
+        empty_fmt = workbook.add_format({'bg_color': '#F2F2F2', 'border': 1})
+
+        worksheet.set_column(0, 0, 4)
+        worksheet.set_column(1, 12, 20)
+
+        current_row = 0
+
+        for plate_idx, (plate_key, dilutions) in enumerate(plates_data.items()):
+            if plate_idx > 0:
+                current_row += 3
+
+            plate_num = plate_key.split('_')[1]
+            ratio_parts = [
+                f"Dilution {dk.split('_')[1]}: {dd['ratio']}"
+                for dk, dd in dilutions.items()
+            ]
+            title = f"Plate {plate_num} · " + " | ".join(ratio_parts)
+
+            worksheet.merge_range(current_row, 0, current_row, 12, title, title_fmt)
+            worksheet.set_row(current_row, 20)
+            current_row += 1
+
+            worksheet.write(current_row, 0, '', header_fmt)
+            for col in range(1, 13):
+                worksheet.write(current_row, col, col, header_fmt)
+            current_row += 1
+
+            for row_letter in 'ABCDEFGH':
+                worksheet.write(current_row, 0, row_letter, header_fmt)
+                worksheet.set_row(current_row, 30)
+                for col_num in range(1, 13):
+                    well_name = f"{row_letter}{col_num}"
+                    cell_written = False
+                    for dilution_key, dilution_data in dilutions.items():
+                        if well_name in dilution_data['wells']:
+                            w = dilution_data['wells'][well_name]
+                            dilution_num = int(dilution_key.split('_')[1])
+                            well_fmt = well_fmts.get(dilution_num, well_fmts[1])
+                            label = w['construct'].split(', ')[0]
+                            if self.replicates > 1:
+                                label += f"\nR{w['replicate']}"
+                            worksheet.write(current_row, col_num, label, well_fmt)
+                            cell_written = True
+                            break
+                    if not cell_written:
+                        worksheet.write(current_row, col_num, '', empty_fmt)
+                current_row += 1
+
+        workbook.close()
 
     def run(self, protocol: protocol_api.ProtocolContext):
         #Labware
@@ -441,6 +584,17 @@ class Plating():
         protocol.comment("\n=== Plating protocol complete ===")
         protocol.comment(f"Plated {self.number_constructs} constructs with {self.replicates} replicates")
         protocol.comment(f"Created a total of {self.total_colonies} colonies")
+
+        if protocol.is_simulating():
+            try:
+                output_path = f'{self.protocol_name}.json'
+                self.write_plates_json(output_path)
+                protocol.comment(f"Generated {output_path}")
+                excel_path = f'{self.protocol_name}.xlsx'
+                self.write_plates_excel(excel_path)
+                protocol.comment(f"Generated {excel_path}")
+            except Exception as e:
+                protocol.comment(f"Could not export plating layout: {e}")
 
 
 @dataclass

--- a/src/pudu/plating.py
+++ b/src/pudu/plating.py
@@ -317,25 +317,36 @@ class Plating():
         plates: Dict = {}
 
         for dilution_step in range(1, self.number_dilutions + 1):
-            if self.number_dilutions == 2 and agar_wells_per > 48:
-                plate_key = f'plate_{dilution_step}'
-                start_idx = 0
-            else:
-                plate_key = 'plate_1'
-                start_idx = 0 if dilution_step == 1 else 48
-
             ratio = self._dilution_ratio_label(dilution_step)
             dilution_key = f'dilution_{dilution_step}'
 
-            if plate_key not in plates:
-                plates[plate_key] = {}
-            plates[plate_key][dilution_key] = {'ratio': ratio, 'wells': {}}
+            if self.number_dilutions == 2 and agar_wells_per > 48:
+                # Each dilution gets its own plate starting at index 0
+                base_plate = dilution_step
+                base_idx = 0
+            else:
+                # Both dilutions share plate_1; dilution_2 starts at the halfway point
+                base_plate = 1
+                base_idx = 0 if dilution_step == 1 else 48
 
             for construct_idx, (source_well, construct_names) in enumerate(constructs):
                 name_str = self._format_construct_name(construct_names)
                 for replicate in range(self.replicates):
-                    well_idx = start_idx + construct_idx * self.replicates + replicate
-                    well_name = self._well_name_from_index(well_idx)
+                    absolute_idx = base_idx + construct_idx * self.replicates + replicate
+
+                    if absolute_idx < 96:
+                        plate_key = f'plate_{base_plate}'
+                        mapped_idx = absolute_idx
+                    else:
+                        plate_key = f'plate_{base_plate + 1}'
+                        mapped_idx = absolute_idx - 96
+
+                    if plate_key not in plates:
+                        plates[plate_key] = {}
+                    if dilution_key not in plates[plate_key]:
+                        plates[plate_key][dilution_key] = {'ratio': ratio, 'wells': {}}
+
+                    well_name = self._well_name_from_index(mapped_idx)
                     plates[plate_key][dilution_key]['wells'][well_name] = {
                         'construct': name_str,
                         'source_well': source_well,

--- a/src/pudu/plating.py
+++ b/src/pudu/plating.py
@@ -6,10 +6,39 @@ from opentrons import protocol_api
 
 class Plating():
     """
-    Creates a protocol for automated plating of transformed bacteria
+    Automated serial-dilution and spot-plating protocol for the Opentrons OT-2.
+
+    Takes transformed bacteria from a thermocycler plate, performs up to two
+    sequential 10× (or custom) dilutions in a dilution plate, and spots each
+    dilution onto an agar plate. Supports multiple replicates and automatically
+    distributes across two physical plates when colony counts exceed 96.
+
+    After simulation, writes a JSON and an Excel file mapping each agar-plate
+    well to the construct name, dilution ratio, and replicate number.
 
     Attributes:
-
+        volume_total_reaction: Volume of bacteria loaded in each thermocycler
+            source well, in µL. Used for liquid-tracking display only.
+        volume_bacteria_transfer: Volume transferred from each source well into
+            the dilution well, in µL.
+        volume_colony: Volume spotted from each dilution well onto the agar
+            plate per replicate, in µL.
+        dilution_factor: Serial dilution factor applied at each step (e.g. 10
+            for a 1:10 dilution). The LB volume pre-loaded into each dilution
+            well is ``volume_bacteria_transfer × (dilution_factor − 1)``.
+        volume_lb: Total LB volume in the stock tube, in µL. Used for liquid
+            tracking on the Opentrons deck visualiser.
+        replicates: Number of agar spots per construct per dilution step.
+        number_dilutions: Number of serial dilution steps to perform (max 2).
+        number_constructs: Number of unique constructs derived from
+            ``bacterium_locations``.
+        total_colonies: Total agar wells that will be plated
+            (``number_constructs × number_dilutions × replicates``).
+        max_colonies: Hard cap on ``total_colonies``; raises ``ValueError``
+            if exceeded.
+        bacterium_locations: Dict mapping thermocycler well names to construct
+            identifiers, e.g. ``{'A1': 'GFP_construct', 'B1': ['RFP', 'v2']}``.
+        protocol_name: Base name for output files (JSON and Excel).
     """
     def __init__(self,
                  plating_data: Optional[Dict] = None,
@@ -312,6 +341,21 @@ class Plating():
         return f"1/{factor_int}"
 
     def build_agar_plate_map(self) -> Dict:
+        """
+        Build a nested mapping of agar plate wells to construct metadata.
+
+        Returns a dict keyed by plate (``'plate_1'``, ``'plate_2'``) then by
+        dilution step (``'dilution_1'``, ``'dilution_2'``). Each dilution entry
+        contains ``'ratio'`` (e.g. ``'1/10'``) and ``'wells'``, a dict mapping
+        well names (e.g. ``'A1'``) to ``{'construct', 'source_well', 'replicate'}``.
+
+        When both dilutions fit on a single 96-well plate (≤ 48 wells per
+        dilution), they are placed in the top and bottom halves respectively.
+        When a dilution exceeds 48 wells, each step gets its own physical plate.
+
+        Returns:
+            Nested dict describing the complete agar plate layout.
+        """
         constructs = list(self.bacterium_locations.items())
         agar_wells_per = self.number_constructs * self.replicates
         plates: Dict = {}
@@ -356,15 +400,38 @@ class Plating():
         return plates
 
     def get_plates_json(self) -> Dict:
+        """Return the full agar plate map wrapped under an ``'agar_plates'`` key."""
         return {'agar_plates': self.build_agar_plate_map()}
 
     def write_plates_json(self, output_path: str) -> Dict:
+        """
+        Serialize the agar plate map to a JSON file and return the data dict.
+
+        Args:
+            output_path: Filesystem path for the output JSON file.
+
+        Returns:
+            The same dict that was written to disk.
+        """
         data = self.get_plates_json()
         with open(output_path, 'w') as f:
             json.dump(data, f, indent=2)
         return data
 
     def write_plates_excel(self, output_path: str) -> None:
+        """
+        Write a colour-coded Excel representation of the agar plate map.
+
+        Each physical plate becomes a 8 × 12 grid in the worksheet, with cells
+        colour-coded by dilution step (blue for dilution 1, orange for dilution 2)
+        and labelled with the construct name and replicate number.
+
+        Args:
+            output_path: Filesystem path for the output ``.xlsx`` file.
+
+        Raises:
+            ImportError: If ``xlsxwriter`` is not installed.
+        """
         try:
             import xlsxwriter
         except ImportError:
@@ -444,6 +511,30 @@ class Plating():
         workbook.close()
 
     def run(self, protocol: protocol_api.ProtocolContext):
+        """
+        Execute the automated plating protocol on the OT-2.
+
+        Deck layout (default positions):
+            - Slot 7/8/10/11: Thermocycler module (source bacteria in PCR plate)
+            - Slot 1: Large tip rack (200 µL, for LB distribution)
+            - Slot 9: Small tip rack (20 µL, for bacteria and agar transfers)
+            - Slot 4: Tube rack with LB stock tube
+            - Slot 2 (and 3 if needed): Dilution plate(s)
+            - Slot 5 (and 6 if needed): Agar plate(s)
+
+        Protocol steps:
+            1. Distribute LB into all dilution wells using a single large-pipette
+               tip (one aspiration height adjustment per 8-well chunk).
+            2. For each construct: transfer bacteria → dilution 1, mix, seed
+               dilution 2 (if requested), then spot dilution 1 onto agar.
+            3. With a fresh tip, spot dilution 2 onto agar.
+
+        On simulation, writes ``{protocol_name}.json`` and ``{protocol_name}.xlsx``
+        describing the agar plate layout.
+
+        Args:
+            protocol: Opentrons ``ProtocolContext`` provided by the OT-2 runtime.
+        """
         #Labware
         #Load the thermocycler module, its default location is on slots 7, 8, 10 and 11
         thermocycler = protocol.load_module('thermocyclerModuleV1')

--- a/src/pudu/sample_preparation.py
+++ b/src/pudu/sample_preparation.py
@@ -23,6 +23,29 @@ class SamplePreparation(ABC):
                  use_temperature_module: bool = False,
                  temperature: int = 4,
                  **kwargs):
+        """
+        Initialize shared sample preparation hardware parameters.
+
+        Args:
+            test_labware: Opentrons labware definition string for the destination
+                plate (e.g. a flat-bottom 96-well plate for absorbance readings).
+            test_position: Deck slot string for the destination plate.
+            aspiration_rate: Aspiration speed as a fraction of the pipette's
+                maximum flow rate (``1.0`` = full speed).
+            dispense_rate: Dispense speed as a fraction of the pipette's maximum
+                flow rate.
+            tiprack_labware: Opentrons labware definition string for the tip rack.
+            tiprack_position: Deck slot string for the tip rack.
+            starting_tip: Well name of the first tip to use (e.g. ``'B1'``).
+                When ``None``, starts from ``'A1'``.
+            pipette: Opentrons pipette model string (e.g. ``'p300_single_gen2'``).
+            pipette_position: Mount side for the pipette (``'left'`` or ``'right'``).
+            use_temperature_module: If ``True``, load the source rack on a
+                temperature module instead of a plain tube rack.
+            temperature: Target temperature in °C for the temperature module.
+                Only used when ``use_temperature_module=True``.
+            **kwargs: Additional keyword arguments passed to subclasses.
+        """
         self.test_labware = test_labware
         self.test_position = test_position
         self.aspiration_rate = aspiration_rate
@@ -110,8 +133,12 @@ class SamplePreparation(ABC):
 
 class PlateSamples(SamplePreparation):
     """
-    Distributes multiple samples across a plate with replicates.
-    Each sample gets distributed to a specified number of wells.
+    Distribute multiple samples across a 96-well plate with column-grouped replicates.
+
+    Each sample is dispensed into ``replicates`` consecutive wells within the same
+    column group. Samples are loaded sequentially from a source tube rack (or
+    temperature module), and the plate layout is recorded in ``result_dict`` for
+    downstream analysis.
     """
 
     def __init__(self, samples: List[str],
@@ -124,6 +151,29 @@ class PlateSamples(SamplePreparation):
                  tube_rack_position: str = '3',
                  tube_rack_labware: str = 'opentrons_24_tuberack_nest_1.5ml_snapcap',
                  **kwargs):
+        """
+        Initialize PlateSamples protocol.
+
+        Args:
+            samples: Ordered list of sample names. Each name maps to one source
+                tube and one well group on the destination plate.
+            sample_volume: Volume to dispense into each replicate well, in µL.
+            sample_stock_volume: Volume of each sample stock tube, in µL. Used
+                for liquid tracking on the Opentrons deck visualiser.
+            replicates: Number of replicate wells per sample on the destination
+                plate.
+            starting_slot: 1-based index of the first column slot to use on the
+                destination plate. Allows pre-filling some slots before this
+                protocol runs.
+            temp_module_position: Deck slot string for the temperature module
+                (used when ``use_temperature_module=True``).
+            temp_module_labware: Opentrons labware definition string for the
+                aluminum block on the temperature module.
+            tube_rack_position: Deck slot string for the source tube rack.
+            tube_rack_labware: Opentrons labware definition string for the source
+                tube rack.
+            **kwargs: Passed to ``SamplePreparation.__init__``.
+        """
         super().__init__(**kwargs)
         self.samples = samples
         self.sample_volume = sample_volume
@@ -139,6 +189,21 @@ class PlateSamples(SamplePreparation):
         self.plate_layout = {}
 
     def run(self, protocol: protocol_api.ProtocolContext):
+        """
+        Execute the sample distribution protocol on the OT-2.
+
+        Loads source tubes, validates plate capacity, then distributes each
+        sample into ``replicates`` wells using the pipette ``distribute`` command
+        (single tip per sample). Results are stored in ``result_dict`` with keys
+        ``'source_positions'`` and ``'plate_layout'``.
+
+        Args:
+            protocol: Opentrons ``ProtocolContext`` provided by the OT-2 runtime.
+
+        Raises:
+            ValueError: If the number of samples exceeds source rack or plate
+                slot capacity.
+        """
         # Load labware
         tiprack, pipette, plate = self._load_standard_labware(protocol)
         source_rack = self._load_source_labware(
@@ -198,8 +263,16 @@ class PlateSamples(SamplePreparation):
 
 class PlateWithGradient(SamplePreparation):
     """
-    Creates serial dilution gradients of an inducer with a sample.
-    Implements proper well-to-well serial dilution.
+    Create a serial inducer-concentration gradient across a 96-well plate.
+
+    The first well in each replicate row receives a stock mixture of sample and
+    inducer at ``initial_concentration``. Each subsequent well is diluted by
+    ``dilution_factor`` through sequential well-to-well transfers, producing a
+    ``dilution_steps``-point gradient. The sample serves as the diluent.
+
+    Typical use case: dose-response characterisation of a genetic circuit where
+    the sample is a cell culture and the inducer is a small molecule (e.g. IPTG,
+    arabinose).
     """
 
     def __init__(self,
@@ -211,8 +284,8 @@ class PlateWithGradient(SamplePreparation):
                  replicates: int = 3,
                  starting_row: str = 'A',
                  final_well_volume: float = 200,
-                 initial_mix_ratio: float = 0.5,  # fraction of inducer in initial mix
-                 transfer_volume: float = 100,  # volume transferred in each dilution step
+                 initial_mix_ratio: float = 0.5,
+                 transfer_volume: float = 100,
                  sample_stock_volume: float = 1200,
                  inducer_stock_volume: float = 1200,
                  temp_module_position: str = '1',
@@ -220,7 +293,41 @@ class PlateWithGradient(SamplePreparation):
                  tube_rack_position: str = '3',
                  tube_rack_labware: str = 'opentrons_24_tuberack_nest_1.5ml_snapcap',
                  **kwargs):
+        """
+        Initialize PlateWithGradient protocol.
 
+        Args:
+            sample_name: Human-readable name for the sample (e.g. ``'DH5alpha_GFP'``).
+                Used for liquid tracking labels.
+            inducer_name: Human-readable name for the inducer (e.g. ``'IPTG'``).
+            initial_concentration: Inducer concentration in the first well, in
+                whatever units the user chooses (e.g. mM, ng/µL). Used only for
+                labelling ``concentration_map``; does not affect volumes.
+            dilution_factor: Factor by which concentration decreases at each step
+                (e.g. ``2.0`` for 2-fold dilutions).
+            dilution_steps: Number of dilution transfers after the initial well,
+                giving ``dilution_steps + 1`` total wells per replicate row.
+            replicates: Number of replicate rows on the plate.
+            starting_row: Letter of the first plate row to use (e.g. ``'A'``).
+            final_well_volume: Target total volume in each well after all additions,
+                in µL. The diluent (sample) pre-fill volume is
+                ``final_well_volume − transfer_volume``.
+            initial_mix_ratio: Fraction of ``final_well_volume`` that is inducer
+                in the first well (e.g. ``0.5`` → equal parts inducer and sample).
+            transfer_volume: Volume moved from each well to the next during the
+                serial dilution, in µL.
+            sample_stock_volume: Total volume of the sample stock tube, in µL.
+                Used for liquid tracking.
+            inducer_stock_volume: Total volume of the inducer stock tube, in µL.
+                Used for liquid tracking.
+            temp_module_position: Deck slot string for the temperature module.
+            temp_module_labware: Opentrons labware definition string for the
+                aluminum block on the temperature module.
+            tube_rack_position: Deck slot string for the source tube rack.
+            tube_rack_labware: Opentrons labware definition string for the source
+                tube rack.
+            **kwargs: Passed to ``SamplePreparation.__init__``.
+        """
         super().__init__(**kwargs)
         self.sample_name = sample_name
         self.inducer_name = inducer_name

--- a/src/pudu/utils.py
+++ b/src/pudu/utils.py
@@ -166,10 +166,34 @@ class Camera:
 
 class SmartPipette:
     """
-    Wrapper for automatic volume tracking
+    Opentrons pipette wrapper that uses the API's liquid-tracking system to
+    compute safe aspiration heights for conical tubes.
+
+    For standard flat-bottom or round-bottom wells, ``SmartPipette`` behaves
+    identically to the underlying pipette. For conical tubes (detected by labware
+    name or the ``use`` flag), it queries the current liquid volume via
+    ``well.current_liquid_volume()`` and converts that to a millimetre height,
+    keeping the tip above the meniscus and away from the narrow tip of the cone.
+
+    This prevents the pipette tip from plunging into an empty tube or aspirating
+    air when a tube is nearly empty — a common failure mode in protocols that
+    dispense large total volumes from a single stock tube (e.g. LB distribution
+    during plating).
     """
 
     def __init__(self, pipette, protocol):
+        """
+        Initialize SmartPipette.
+
+        Args:
+            pipette: A loaded Opentrons pipette instrument object.
+            protocol: The active ``ProtocolContext``. Must support
+                ``define_liquid`` (API level ≥ 2.14).
+
+        Raises:
+            RuntimeError: If the protocol context does not expose liquid
+                tracking (API level too old).
+        """
         self.pipette = pipette
         self.protocol = protocol
         if not hasattr(protocol, 'define_liquid'):

--- a/tests/test_plating.py
+++ b/tests/test_plating.py
@@ -9,6 +9,7 @@ Tests are split into:
   - TestPlateLayout         : calculate_plate_layout single/double plate logic
 """
 
+import json
 import unittest
 from unittest.mock import MagicMock
 from pudu.plating import Plating
@@ -335,6 +336,144 @@ class TestPlateLayout(unittest.TestCase):
 
         self.assertEqual(len(dil_layout['dilution_1']['wells']), 3)
         self.assertEqual(len(agar_layout['dilution_1']['wells']), 12)
+
+
+# ---------------------------------------------------------------------------
+# 6. Plating JSON outputs
+# ---------------------------------------------------------------------------
+
+class TestPlatingOutputs(unittest.TestCase):
+
+    def test_well_name_from_index_column_major(self):
+        from pudu.plating import Plating
+        self.assertEqual(Plating._well_name_from_index(0), 'A1')
+        self.assertEqual(Plating._well_name_from_index(1), 'B1')
+        self.assertEqual(Plating._well_name_from_index(7), 'H1')
+        self.assertEqual(Plating._well_name_from_index(8), 'A2')
+        self.assertEqual(Plating._well_name_from_index(48), 'A7')
+
+    def test_format_construct_name_list(self):
+        from pudu.plating import Plating
+        self.assertEqual(Plating._format_construct_name(['DH5alpha', 'plasmid_1']), 'DH5alpha, plasmid_1')
+
+    def test_format_construct_name_string(self):
+        from pudu.plating import Plating
+        self.assertEqual(Plating._format_construct_name('construct'), 'construct')
+
+    def test_dilution_ratio_label(self):
+        p = make_plating(dilution_factor=10)
+        self.assertEqual(p._dilution_ratio_label(1), '1/10')
+        self.assertEqual(p._dilution_ratio_label(2), '1/100')
+
+    def test_dilution_ratio_label_factor_5(self):
+        p = make_plating(dilution_factor=5)
+        self.assertEqual(p._dilution_ratio_label(1), '1/5')
+        self.assertEqual(p._dilution_ratio_label(2), '1/25')
+
+    def test_build_agar_plate_map_structure(self):
+        p = make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=2)
+        plates = p.build_agar_plate_map()
+        self.assertIn('plate_1', plates)
+        self.assertIn('dilution_1', plates['plate_1'])
+        self.assertIn('dilution_2', plates['plate_1'])
+        self.assertIn('ratio', plates['plate_1']['dilution_1'])
+        self.assertIn('wells', plates['plate_1']['dilution_1'])
+
+    def test_build_agar_plate_map_ratio_labels(self):
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=2, dilution_factor=10)
+        plates = p.build_agar_plate_map()
+        self.assertEqual(plates['plate_1']['dilution_1']['ratio'], '1/10')
+        self.assertEqual(plates['plate_1']['dilution_2']['ratio'], '1/100')
+
+    def test_build_agar_plate_map_well_positions(self):
+        """
+        3 constructs, 2 replicates: dilution_1 wells are A1-F1 (indices 0-5),
+        dilution_2 wells start at index 48 (A7).
+        """
+        p = make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=2)
+        plates = p.build_agar_plate_map()
+        dil1_wells = plates['plate_1']['dilution_1']['wells']
+        dil2_wells = plates['plate_1']['dilution_2']['wells']
+        self.assertIn('A1', dil1_wells)
+        self.assertIn('B1', dil1_wells)
+        self.assertEqual(len(dil1_wells), 6)  # 3 constructs × 2 replicates
+        self.assertIn('A7', dil2_wells)
+
+    def test_build_agar_plate_map_replicate_numbering(self):
+        p = make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=1)
+        plates = p.build_agar_plate_map()
+        wells = plates['plate_1']['dilution_1']['wells']
+        # construct 0 → A1 (rep 1), B1 (rep 2)
+        self.assertEqual(wells['A1']['replicate'], 1)
+        self.assertEqual(wells['B1']['replicate'], 2)
+        self.assertEqual(wells['A1']['source_well'], 'A1')
+
+    def test_build_agar_plate_map_construct_name(self):
+        p = make_plating(SINGLE_CONSTRUCT, number_dilutions=1)
+        plates = p.build_agar_plate_map()
+        well = plates['plate_1']['dilution_1']['wells']['A1']
+        self.assertEqual(well['construct'], 'DH5alpha, plasmid_1')
+
+    def test_build_agar_plate_map_two_plates_when_overflow(self):
+        """
+        When number_constructs * replicates > 48 with 2 dilutions, each
+        dilution step gets its own plate.
+        """
+        locs = {f'A{i+1}': [f'construct_{i}'] for i in range(25)}
+        p = make_plating(locs, replicates=2, number_dilutions=2)
+        # 25 * 2 = 50 wells per dilution > 48 → two plates
+        plates = p.build_agar_plate_map()
+        self.assertIn('plate_1', plates)
+        self.assertIn('plate_2', plates)
+        self.assertIn('dilution_1', plates['plate_1'])
+        self.assertIn('dilution_2', plates['plate_2'])
+
+    def test_get_plates_json_top_level_key(self):
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=2)
+        data = p.get_plates_json()
+        self.assertIn('agar_plates', data)
+        self.assertIsInstance(data['agar_plates'], dict)
+
+    def test_write_plates_json_creates_valid_file(self):
+        import tempfile, os
+        p = make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=2)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'plating_layout.json')
+            returned = p.write_plates_json(path)
+            self.assertTrue(os.path.exists(path))
+            with open(path) as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded, returned)
+            self.assertIn('agar_plates', loaded)
+
+    def test_write_plates_excel_creates_valid_file(self):
+        import tempfile, os, zipfile
+        p = make_plating(THREE_CONSTRUCTS, replicates=2, number_dilutions=2)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'plating_layout.xlsx')
+            p.write_plates_excel(path)
+            self.assertTrue(os.path.exists(path))
+            self.assertGreater(os.path.getsize(path), 0)
+            self.assertTrue(zipfile.is_zipfile(path))
+
+    def test_write_plates_excel_two_plates(self):
+        import tempfile, os, zipfile
+        locs = {f'A{i+1}': [f'construct_{i}'] for i in range(25)}
+        p = make_plating(locs, replicates=2, number_dilutions=2)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'plating_layout.xlsx')
+            p.write_plates_excel(path)
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(zipfile.is_zipfile(path))
+
+    def test_write_plates_excel_single_dilution(self):
+        import tempfile, os, zipfile
+        p = make_plating(THREE_CONSTRUCTS, number_dilutions=1)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'plating_layout.xlsx')
+            p.write_plates_excel(path)
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(zipfile.is_zipfile(path))
 
 
 if __name__ == '__main__':

--- a/tests/test_plating.py
+++ b/tests/test_plating.py
@@ -428,6 +428,26 @@ class TestPlatingOutputs(unittest.TestCase):
         self.assertIn('dilution_1', plates['plate_1'])
         self.assertIn('dilution_2', plates['plate_2'])
 
+    def test_build_agar_plate_map_single_dilution_overflow(self):
+        """
+        When number_dilutions == 1 and number_constructs * replicates > 96,
+        wells should spill onto plate_2 rather than generating invalid well names.
+        """
+        locs = {f'W{i}': f'construct_{i}' for i in range(97)}
+        p = make_plating(locs, number_dilutions=1)
+        plates = p.build_agar_plate_map()
+        self.assertIn('plate_1', plates)
+        self.assertIn('plate_2', plates)
+        self.assertEqual(len(plates['plate_1']['dilution_1']['wells']), 96)
+        self.assertEqual(len(plates['plate_2']['dilution_1']['wells']), 1)
+        # overflow starts fresh at A1 on plate_2
+        self.assertIn('A1', plates['plate_2']['dilution_1']['wells'])
+        # no well name should exceed column 12
+        for plate in plates.values():
+            for dil in plate.values():
+                for well in dil['wells']:
+                    self.assertLessEqual(int(well[1:]), 12)
+
     def test_get_plates_json_top_level_key(self):
         p = make_plating(THREE_CONSTRUCTS, number_dilutions=2)
         data = p.get_plates_json()


### PR DESCRIPTION
Adds build_agar_plate_map() to generate a structured map of all agar plate wells, keyed by plate and dilution
Adds write_plates_json() / get_plates_json() to export the plate map as JSON during simulation
Adds write_plates_excel() to export a visual 96-well plate grid — both dilutions shown in the same plate section (blue = dilution 1, orange = dilution 2), plate sections stacked when two physical plates are used
Output filenames controlled by the new protocol_name parameter (default: plating_layout)
Both files generated automatically at the end of opentrons_simulate